### PR TITLE
Remove reference to private channel

### DIFF
--- a/docs/getting_started/emergency-break-glass.md
+++ b/docs/getting_started/emergency-break-glass.md
@@ -1,11 +1,11 @@
 # Emergency Break Glass Procedure
 
-In the Slack [#devops-alerts](https://mit.enterprise.slack.com/archives/GBDLJJX51) channel,
-simple type:
+In Slack, simply type:
 
 ```
 /rootly page
 ```
+
 
 At this point you'll be presented with a dialog that looks something like this:
 


### PR DESCRIPTION
### Description (What does it do?)
Just removes the reference to the #devops-alerts channel since we can fire off rootly pages from anywhere!

### Additional Context
Slack w/ discussion https://mitodl.slack.com/archives/G3A5RSFDJ/p1757372218394979?thread_ts=1757368050.525149&cid=G3A5RSFDJ

