### PR TITLE
Dansubak/202510 tweak jupyterhub docs

### DIFF
--- a/docs/application_specific_guides/jupyterhub/jupyterhub_admin_guide.md
+++ b/docs/application_specific_guides/jupyterhub/jupyterhub_admin_guide.md
@@ -21,8 +21,9 @@ Culling is performed via the [jupyterhub-idle-culler](https://github.com/jupyter
 # Monitoring
 
 We maintain a [Grafana dashboard](https://mitolproduction.grafana.net/d/ds6qvrm/jupyter-notebooks) which shows some basic metrics about the Jupyterhub deployment. This includes:
-    - kube_pod_container_info: shows which images notebook containers are currently running.
-    - kube_pod_container_status_restarts_total: shows how many times notebook containers have restarted. This being non-zero may be indicative of OOMKills.
+
+- kube_pod_container_info: shows which images notebook containers are currently running.
+- kube_pod_container_status_restarts_total: shows how many times notebook containers have restarted. This being non-zero may be indicative of OOMKills.
 
 ## Authoring Workflow
 

--- a/docs/application_specific_guides/jupyterhub/jupyterhub_admin_guide.md
+++ b/docs/application_specific_guides/jupyterhub/jupyterhub_admin_guide.md
@@ -18,6 +18,12 @@ Jupyterhub domains are currently gated by an SSO login to the olapps Keycloak re
 
 Culling is performed via the [jupyterhub-idle-culler](https://github.com/jupyterhub/jupyterhub-idle-culler) configured via [Helm chart](https://z2jh.jupyter.org/en/latest/resources/reference.html#cull). It currently culls both running, inactive servers as well as users. Culling users is important as we will accumulate UUID-keyed users and sessions in the database over time.
 
+# Monitoring
+
+We maintain a [Grafana dashboard](https://mitolproduction.grafana.net/d/ds6qvrm/jupyter-notebooks) which shows some basic metrics about the Jupyterhub deployment. This includes:
+    - kube_pod_container_info: shows which images notebook containers are currently running.
+    - kube_pod_container_status_restarts_total: shows how many times notebook containers have restarted. This being non-zero may be indicative of OOMKills.
+
 ## Authoring Workflow
 
 ### Adding a New Course

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,8 +50,6 @@ nav:
       - Transitioning Postgres DB to RDS: application_specific_guides/heroku_legacy/transition_postgres_db_to_rds.md
     - OCW Studio:
       - Updating The OCW Studio Pipeline: application_specific_guides/ocw-studio/Update_OCW_Studio_Pipeline.md
-    - ODL-bot / Doof:
-      - Updating odlbot/doof Github Access Token: application_specific_guides/odlbot/Resetting_Doof_Github_Token.md
     - Renovate: 
       - Updating Renovate Configuration: application_specific_guides/renovate/updating_renovate_config.md
     - JupyterHub:


### PR DESCRIPTION
### Description (What does it do?)
Adds a link to where the Jupyterhub dashboard is gonna live w/ some explanation as to what the metrics of note are.

Also removes a busted link encountered during build:
```
daniel@dansubak-macbook platform-engineering-site % uv run mkdocs build
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /Users/daniel/repos/platform-engineering-site/site
WARNING -  A reference to 'application_specific_guides/odlbot/Resetting_Doof_Github_Token.md' is included in the 'nav'
           configuration, which is not found in the documentation files.
INFO    -  Documentation built in 0.30 seconds
```


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
