### PR TITLE
Add OpenMetadata catalog lineage as a second c4gen extractor source

### DIFF
--- a/architecture_maps/README.md
+++ b/architecture_maps/README.md
@@ -24,8 +24,17 @@ Two halves, each playing to its strength:
 
 | Half | What it does | Why |
 | --- | --- | --- |
-| **Deterministic** (`extract.py`) | Reads the **witan-code** cross-repo graph and emits the cross-service edge *candidates* + cycle report. | Edges come from real code contracts, refresh on demand, and can run in CI. No drift. |
-| **Curated** (`models/<system>.yaml`) | Humans/LLM author node prose, the verified flows actually drawn, async/ETL flows, and scenario narratives. | The graph can't see async flows (Celery/ETL/events) and produces *phantom* edges from shared endpoint paths or load-testing clients. Curation confirms and enriches. |
+| **Deterministic** (`extract.py` + `openmetadata.py`) | Two lineage sources emit cross-service edge *candidates* + a cycle report: the **witan-code** cross-repo code graph (runtime HTTP contracts) and the **OpenMetadata** catalog (warehouse/dbt data lineage). | Edges come from real code contracts and real data lineage, refresh on demand, and can run in CI. No drift. |
+| **Curated** (`models/<system>.yaml`) | Humans/LLM author node prose, the verified flows actually drawn, async/ETL flows, and scenario narratives. | Neither source sees everything (the code graph misses ETL/events; lineage misses sync request paths) and both produce *phantom* edges (shared endpoint paths, load-testing clients, name-prefix mis-attribution). Curation confirms and enriches. |
+
+The two deterministic sources are complementary: the **code graph** captures
+synchronous service-to-service HTTP calls; **OpenMetadata lineage** captures the
+asynchronous data-platform flows (each service's tables landing in the lake and
+being joined across systems in dbt). Pick one or merge both with
+`--source {graph,openmetadata,both}` on `extract`/`build`. Candidates carry
+`provenance.derived_from` (`graph` | `openmetadata`) so a reader can tell — and
+trace — where each came from; graph edges link the consumer source file, lineage
+edges link the catalog asset.
 
 The renderer merges them — **curated edges are drawn; raw graph edges appear only
 as labelled candidates** on the Dependencies page, with a caveat to confirm each.
@@ -37,6 +46,7 @@ architecture_maps/
   c4gen/
     schema.py    # the structured model (pydantic): systems, containers, flows, scenarios, etl_sources
     extract.py   # deterministic: witan-code bridge -> cross-service candidates + cycles
+    openmetadata.py # deterministic: OpenMetadata catalog lineage -> cross-service candidates
     puml.py      # model -> C4-PlantUML (Context / Container / Dynamic)
     render.py    # shared rendering helpers (alias/quote/tagline/owner resolution)
     pages.py     # markdown page assembly (legend, tables, provenance, diagram placeholders)
@@ -69,11 +79,33 @@ uv run --directory architecture_maps --group c4gen python -m c4gen extract mit-l
 uv run --directory architecture_maps --group c4gen python -m c4gen build mit-learn    # extract + render
 ```
 
-`extract` (and therefore `build`) requires the **witan-code** tool installed
-(`uv tool install witan-code`) with an indexed graph — it reads the shared bridge
-store the [`witan-code deps`](https://github.com/mitodl/agent-kit) command uses.
-If the repos aren't indexed, run `witan-code index <repo>` first. A non-authoring
+`extract` (and therefore `build`) defaults to the **witan-code** graph source,
+which requires the witan-code tool installed (`uv tool install witan-code`) with
+an indexed graph — it reads the shared bridge store the
+[`witan-code deps`](https://github.com/mitodl/agent-kit) command uses. If the
+repos aren't indexed, run `witan-code index <repo>` first. A non-authoring
 contributor who only changed a model usually just needs `render` + Kroki.
+
+To pull the **OpenMetadata** data-lineage source instead of (or alongside) the
+graph, set `C4GEN_OPENMETADATA_URL` to the catalog base URL (e.g.
+`https://data.ol.mit.edu`) and `C4GEN_OPENMETADATA_TOKEN` to a JWT bot token,
+then pass `--source openmetadata` or `--source both`:
+
+```bash
+export C4GEN_OPENMETADATA_URL=https://data.ol.mit.edu C4GEN_OPENMETADATA_TOKEN=...
+uv run --directory architecture_maps --group c4gen python -m c4gen extract mit-learn --source both
+```
+
+OpenMetadata attributes each warehouse table to a source system via its
+`<layer>__<source>__…` name prefix and emits a candidate edge wherever a single
+downstream table is fed by more than one source system (a cross-service join), or
+a cross-cutting `combined` model feeds the synthetic `ol-data-platform` node.
+When the catalog is unset or unreachable the source degrades to an empty slice,
+so `--source both` never breaks a graph-only run.
+
+> Note: `extract` writes the *combined* slice to `models/<system>.graph.yaml`.
+> Running `--source openmetadata` alone overwrites the graph slice (and vice
+> versa); use `--source both` to refresh both at once.
 
 The generated pages carry a "do not hand-edit" banner; the only files you edit by
 hand are `models/<system>.yaml` and the curated

--- a/architecture_maps/c4gen/cli.py
+++ b/architecture_maps/c4gen/cli.py
@@ -2,14 +2,16 @@
 
 Hybrid pipeline:
 
-    extract   witan-code graph  -> models/<name>.graph.yaml (+ .cycles.json)
-    render    curated + graph    -> docs/.../architecture/*.md + _diagrams/*.svg
+    extract   witan-code graph + OpenMetadata lineage -> models/<name>.graph.yaml (+ .cycles.json)
+    render    curated + extracted slice               -> docs/.../architecture/*.md + _diagrams/*.svg
     build     = extract then render
 
 The curated model (``models/<name>.yaml``) holds nodes, async/code-derived
 flows, and scenario narratives. The extractor refreshes the deterministic
-cross-service slice. The renderer merges them (curated wins), renders each
-diagram to SVG via Kroki (see ``puml.py``), and writes the pages.
+cross-service slice from two lineage sources — the witan-code code graph
+(``extract.py``) and the OpenMetadata catalog (``openmetadata.py``) — pick which
+with ``--source {graph,openmetadata,both}``. The renderer merges them (curated
+wins), renders each diagram to SVG via Kroki (see ``puml.py``), and writes the pages.
 """
 
 from __future__ import annotations
@@ -17,6 +19,7 @@ from __future__ import annotations
 import datetime
 import json
 import os
+from enum import StrEnum
 from importlib import metadata
 from pathlib import Path
 from urllib import error, request
@@ -25,9 +28,18 @@ import cyclopts
 import yaml
 
 from . import extract as extract_mod
+from . import openmetadata as omd_mod
 from . import pages as pages_mod
 from . import puml as puml_mod
 from .schema import Flow, Model
+
+
+class Source(StrEnum):
+    """Which deterministic lineage source(s) ``extract`` queries."""
+
+    GRAPH = "graph"  # witan-code cross-repo code graph (HTTP contracts)
+    OPENMETADATA = "openmetadata"  # OpenMetadata catalog asset lineage (warehouse)
+    BOTH = "both"
 
 app = cyclopts.App(name="c4gen", help="Generate C4 data-flow docs (C4-PlantUML via Kroki).")
 
@@ -91,21 +103,66 @@ def _merge_systems(curated: dict, slice_: dict) -> dict:
     return merged
 
 
+def _merge_slices(*slices: dict) -> dict:
+    """Union systems (by id) and flows (by id) across lineage-source slices.
+
+    Each source emits the same intermediate shape; this concatenates them so the
+    graph slice (witan-code) and the OpenMetadata lineage slice land in one
+    ``.graph.yaml`` and feed cycle detection / the candidate table together.
+    """
+    systems: dict[str, dict] = {}
+    flows: dict[str, dict] = {}
+    for s in slices:
+        for sysd in s.get("systems", []):
+            systems.setdefault(sysd["id"], sysd)
+        for flow in s.get("flows", []):
+            flows.setdefault(flow["id"], flow)
+    return {"systems": list(systems.values()), "flows": list(flows.values())}
+
+
 @app.command
-def extract(name: str) -> None:
-    """Refresh the deterministic cross-service slice for model ``name`` from the graph."""
-    rows = extract_mod.load_bindings()
-    contracts = extract_mod.group_contracts(rows)
-    edges = extract_mod.cross_repo_edges(contracts, kinds=("endpoint",))
-    cycles = extract_mod.find_cycles(edges)
-    slice_ = extract_mod.build_flow_slice(edges)
+def extract(name: str, source: Source = Source.GRAPH) -> None:
+    """Refresh the deterministic cross-service slice for model ``name``.
+
+    ``--source`` selects the lineage source: ``graph`` (witan-code code graph,
+    the default), ``openmetadata`` (catalog asset lineage), or ``both`` (union).
+    The OpenMetadata source degrades to an empty slice when its server is unset
+    or unreachable, so ``both`` never breaks a graph-only run.
+    """
+    graph_slice: dict = {"systems": [], "flows": []}
+    omd_slice: dict = {"systems": [], "flows": []}
+
+    if source in (Source.GRAPH, Source.BOTH):
+        rows = extract_mod.load_bindings()
+        contracts = extract_mod.group_contracts(rows)
+        edges = extract_mod.cross_repo_edges(contracts, kinds=("endpoint",))
+        graph_slice = extract_mod.build_flow_slice(edges)
+    if source in (Source.OPENMETADATA, Source.BOTH):
+        omd_slice = omd_mod.extract_slice()
+
+    slice_ = _merge_slices(graph_slice, omd_slice)
+    # Cycles are detected over the combined edge set so cross-source cycles surface.
+    cycles = _cycles_from_slice(slice_)
 
     MODELS_DIR.mkdir(parents=True, exist_ok=True)
     (MODELS_DIR / f"{name}.graph.yaml").write_text(
         yaml.safe_dump(slice_, sort_keys=False, width=100)
     )
     (MODELS_DIR / f"{name}.cycles.json").write_text(json.dumps(cycles, indent=2))
-    print(f"extracted {len(slice_['flows'])} cross-service flows, {len(cycles)} cycles")
+    print(
+        f"extracted {len(slice_['flows'])} cross-service flows "
+        f"({len(graph_slice['flows'])} graph, {len(omd_slice['flows'])} openmetadata), "
+        f"{len(cycles)} cycles"
+    )
+
+
+def _cycles_from_slice(slice_: dict) -> list[list[str]]:
+    """Run cycle detection over a merged slice's flows (system-id level)."""
+    edges = [
+        extract_mod.CrossEdge(src=f["source"], dst=f["target"], kind=f.get("protocol", ""))
+        for f in slice_.get("flows", [])
+    ]
+    return extract_mod.find_cycles(edges)
 
 
 @app.command
@@ -163,9 +220,9 @@ def render(name: str) -> None:
 
 
 @app.command
-def build(name: str) -> None:
-    """Extract then render in one step."""
-    extract(name)
+def build(name: str, source: Source = Source.GRAPH) -> None:
+    """Extract (``--source {graph,openmetadata,both}``) then render in one step."""
+    extract(name, source=source)
     render(name)
 
 

--- a/architecture_maps/c4gen/openmetadata.py
+++ b/architecture_maps/c4gen/openmetadata.py
@@ -1,0 +1,310 @@
+"""Deterministic extractor: OpenMetadata asset lineage -> model flow slice.
+
+The *second* deterministic lineage source, parallel to the witan-code code-graph
+bridge in ``extract.py``. Where the graph sees **runtime HTTP contracts** between
+services, OpenMetadata sees **data lineage** in the OL data platform: the dbt /
+warehouse transformations that pull each source system's tables into the lake and
+join them across systems. Both halves emit the same intermediate
+candidate-edge / ``Model``-slice shape so the renderer treats them identically —
+unverified candidates surfaced on the Dependencies page, not drawn until curated.
+
+How a lineage edge becomes a cross-service flow
+-----------------------------------------------
+The warehouse names every table ``<layer>__<source-system>__...`` (``raw__``,
+``stg__``, ``int__``, ``marts__``, ``combined``...). The ``<source-system>`` token
+(``mitlearn``, ``mitxonline``, ``micromasters``, ...) attributes a table to the
+service whose data it carries. A lineage edge whose upstream and downstream tables
+resolve to *different* source systems is a cross-system data flow inside the
+platform (e.g. a ``marts__combined__*`` model joining ``int__mitxonline__*`` and
+``int__micromasters__*``). Same-system edges (``raw -> stg -> int`` for one source)
+are intra-platform plumbing and are not emitted as cross-service candidates.
+
+Every emitted edge also flows *into* the synthetic ``ol-data-platform`` system
+(the lake itself), so the Context view can show "service X feeds the data
+platform" even when no cross-system join is involved.
+
+Connection
+----------
+This talks to the OpenMetadata REST API the catalog MCP server fronts. Set
+``C4GEN_OPENMETADATA_URL`` (e.g. ``https://catalog.example.edu``) and, if the
+instance requires auth, ``C4GEN_OPENMETADATA_TOKEN`` (a JWT bot token). When the
+server is unset or unreachable, extraction degrades gracefully: it logs a skip
+and returns an empty slice, so ``render`` / the graph source keep working with no
+OpenMetadata present.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from urllib import error, parse, request
+
+# Source-system token (as it appears in warehouse table names) -> model system id.
+# These mirror the system ids the curated models / witan-code graph already use,
+# so OpenMetadata-derived edges line up with graph-derived ones on the same nodes.
+SOURCE_SYSTEM_IDS: dict[str, str] = {
+    "mitlearn": "mit-learn",
+    "mitxonline": "mitxonline",
+    "micromasters": "micromasters",
+    "mitxpro": "mitxpro",
+    "xpro": "mitxpro",
+    "bootcamps": "bootcamps",
+    "edxorg": "edxorg",
+    "edx": "edxorg",
+    "ocw": "ocw",
+}
+
+# The data platform itself, as a system node. Lineage edges terminate here so the
+# Context view can show each service feeding the lake.
+PLATFORM_SYSTEM_ID = "ol-data-platform"
+PLATFORM_SYSTEM_NAME = "OL Data Platform"
+
+# Warehouse layer prefixes, longest-first so ``raw`` doesn't shadow a longer token.
+_LAYER_PREFIXES = ("raw", "stg", "staging", "int", "intermediate", "marts", "mart")
+_NAME_RE = re.compile(r"^(?P<layer>[a-z]+)__(?P<source>[a-z0-9]+)__")
+
+
+def _base_url() -> str | None:
+    url = os.environ.get("C4GEN_OPENMETADATA_URL", "").strip().rstrip("/")
+    return url or None
+
+
+def source_system(table_name: str) -> str | None:
+    """``stg__mitlearn__app__postgres__...`` -> ``mit-learn`` (model system id).
+
+    Returns ``None`` for names that don't carry a recognized source token
+    (``information_schema`` tables, ``combined_*`` reports without a source
+    segment, unknown sources) — the caller skips those.
+    """
+    m = _NAME_RE.match(table_name)
+    if not m or m.group("layer") not in _LAYER_PREFIXES:
+        return None
+    return SOURCE_SYSTEM_IDS.get(m.group("source"))
+
+
+@dataclass
+class CatalogClient:
+    """Thin OpenMetadata REST client (search + lineage), tolerant of an absent server."""
+
+    base_url: str
+    token: str | None = None
+    timeout: int = 30
+
+    def _get(self, path: str, params: dict | None = None) -> dict:
+        url = f"{self.base_url}{path}"
+        if params:
+            url = f"{url}?{parse.urlencode(params)}"
+        headers = {"Accept": "application/json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        req = request.Request(url, headers=headers, method="GET")  # noqa: S310 (trusted catalog URL)
+        with request.urlopen(req, timeout=self.timeout) as resp:  # noqa: S310
+            return json.loads(resp.read().decode("utf-8"))
+
+    def reachable(self) -> bool:
+        try:
+            self._get("/api/v1/system/version")
+            return True
+        except (error.URLError, OSError, ValueError):
+            return False
+
+    def search_tables(self, query: str = "*", size: int = 1000) -> list[dict]:
+        """Page through table-entity search hits (fqn + name), newest API shape."""
+        out: list[dict] = []
+        frm = 0
+        while True:
+            page = self._get(
+                "/api/v1/search/query",
+                {"q": query, "index": "table_search_index", "from": frm, "size": size},
+            )
+            hits = page.get("hits", {}).get("hits", [])
+            if not hits:
+                break
+            out.extend(h.get("_source", {}) for h in hits)
+            frm += len(hits)
+            if len(hits) < size:
+                break
+        return out
+
+    def lineage(self, fqn: str, upstream: int = 3, downstream: int = 0) -> dict:
+        """Lineage graph for a table by fully-qualified name."""
+        return self._get(
+            f"/api/v1/lineage/getLineage/table/name/{parse.quote(fqn, safe='')}",
+            {"upstreamDepth": upstream, "downstreamDepth": downstream},
+        )
+
+
+def _asset_url(base_url: str, fqn: str) -> str:
+    """Deep link into the OpenMetadata UI for a table fqn."""
+    return f"{base_url}/table/{parse.quote(fqn, safe='')}"
+
+
+@dataclass
+class LineageEdge:
+    """An aggregated cross-system lineage edge between two source systems.
+
+    ``dst`` is the source system that the combining table belongs to, or the
+    synthetic platform when the combining table is cross-cutting (a
+    ``marts__combined__*`` model that carries no single source).
+    """
+
+    src: str  # upstream source-system id (where the data originates)
+    dst: str  # downstream system id (the joiner, or the platform)
+    lineage_kinds: set[str] = field(default_factory=set)  # DbtLineage / ViewLineage / ...
+    sample_assets: list[str] = field(default_factory=list)  # combining-table fqns
+    example_asset_fqn: str | None = None
+    example_upstream_fqn: str | None = None
+
+
+def cross_system_edges(client: CatalogClient, tables: list[dict]) -> list[LineageEdge]:
+    """Walk lineage per table; emit an edge wherever 2+ source systems combine.
+
+    For each table we collect the distinct source systems among *all* its upstream
+    nodes (the full lineage subgraph, not just direct parents). When a single
+    downstream table is fed by more than one source system — the signature of a
+    cross-service join in the warehouse — we emit one directed edge per upstream
+    system into the downstream table's system. A downstream table that carries no
+    single source of its own (a ``combined`` mart) is attributed to the synthetic
+    ``ol-data-platform`` system, so "service X feeds the platform" still shows.
+
+    Tables fed by a single source (plain ``raw -> stg -> int`` plumbing) emit
+    nothing: they are intra-service and not cross-service candidates.
+    """
+    by_id: dict[tuple[str, str], LineageEdge] = {}
+
+    for tbl in tables:
+        fqn = tbl.get("fullyQualifiedName")
+        name = tbl.get("name", "")
+        if not fqn:
+            continue
+        down_sys = source_system(name) or PLATFORM_SYSTEM_ID
+        try:
+            graph = client.lineage(fqn)
+        except (error.URLError, OSError, ValueError):
+            continue
+
+        nodes = list(graph.get("nodes", []))
+        entity = graph.get("entity", {})
+        kinds = {
+            e.get("lineageDetails", {}).get("source")
+            for e in graph.get("upstreamEdges", [])
+            if (e.get("lineageDetails") or {}).get("source")
+        }
+        # Distinct upstream source systems feeding this table (exclude itself).
+        upstream: dict[str, str] = {}  # system id -> one example upstream fqn
+        for n in nodes:
+            if n.get("id") == entity.get("id"):
+                continue
+            sys = source_system(n.get("name", ""))
+            if sys and sys != down_sys:
+                upstream.setdefault(sys, n.get("fullyQualifiedName"))
+        if len(upstream) < 2 and down_sys != PLATFORM_SYSTEM_ID:
+            # Single-source (or no cross-source) feed into a service-owned table:
+            # intra-service plumbing, not a cross-service candidate.
+            continue
+        for up_sys, up_fqn in upstream.items():
+            key = (up_sys, down_sys)
+            agg = by_id.get(key)
+            if agg is None:
+                agg = by_id[key] = LineageEdge(up_sys, down_sys)
+            agg.lineage_kinds |= kinds
+            if fqn not in agg.sample_assets:
+                agg.sample_assets.append(fqn)
+            if agg.example_asset_fqn is None:
+                agg.example_asset_fqn = fqn
+                agg.example_upstream_fqn = up_fqn
+    return list(by_id.values())
+
+
+def _ensure_system(systems: dict[str, dict], sid: str, name: str | None = None) -> None:
+    systems.setdefault(
+        sid,
+        {"id": sid, "name": name or sid, "kind": "internal"},
+    )
+
+
+def build_flow_slice(base_url: str, edges: list[LineageEdge]) -> dict:
+    """Turn cross-system lineage edges into a ``Model``-shaped dict (systems + flows).
+
+    Mirrors ``extract.build_flow_slice``: emits bare system stubs (the curated
+    model supplies prose) and one flow per cross-system lineage relation, tagged
+    ``etl`` + ``cross-service`` + ``openmetadata-derived`` and carrying enough
+    provenance (source/downstream asset fqn + catalog deep link) to trace it.
+    """
+    systems: dict[str, dict] = {}
+    _ensure_system(systems, PLATFORM_SYSTEM_ID, PLATFORM_SYSTEM_NAME)
+
+    flows: list[dict] = []
+    for e in edges:
+        _ensure_system(systems, e.src)
+        _ensure_system(systems, e.dst)
+        kinds = ", ".join(sorted(e.lineage_kinds)) or "lineage"
+        n = len(e.sample_assets)
+        flows.append(
+            {
+                "id": f"omd-{e.src}-to-{e.dst}-lineage",
+                "source": e.src,
+                "target": e.dst,
+                "label": f"feeds {n} downstream table{'s' if n != 1 else ''}",
+                "sync": False,  # warehouse transforms are batch/async by nature
+                "protocol": "SQL",
+                "data": f"e.g. {e.example_asset_fqn.split('.')[-1]}"
+                if e.example_asset_fqn
+                else "",
+                "trigger": "etl: warehouse transform",
+                "tags": ["cross-service", "etl", "openmetadata-derived"],
+                "provenance": {
+                    "derived_from": "openmetadata",
+                    "contract_kind": "lineage",
+                    "contract_key": kinds,
+                    "asset_fqn": e.example_asset_fqn,
+                    "asset_url": _asset_url(base_url, e.example_asset_fqn)
+                    if e.example_asset_fqn
+                    else None,
+                },
+            }
+        )
+    return {"systems": list(systems.values()), "flows": flows}
+
+
+def extract_slice() -> dict:
+    """Top-level entry: connect, walk lineage, return a flow slice (or empty if down).
+
+    Returns ``{"systems": [], "flows": []}`` and prints a skip note when no
+    OpenMetadata server is configured or it is unreachable — callers (the CLI)
+    can merge an empty slice harmlessly.
+    """
+    base = _base_url()
+    if base is None:
+        print(
+            "openmetadata: C4GEN_OPENMETADATA_URL not set — skipping lineage source.",
+            file=sys.stderr,
+        )
+        return {"systems": [], "flows": []}
+    client = CatalogClient(base, token=os.environ.get("C4GEN_OPENMETADATA_TOKEN") or None)
+    if not client.reachable():
+        print(
+            f"openmetadata: catalog at {base} unreachable — skipping lineage source.",
+            file=sys.stderr,
+        )
+        return {"systems": [], "flows": []}
+    try:
+        tables = client.search_tables()
+    except error.HTTPError as exc:
+        hint = (
+            " (set C4GEN_OPENMETADATA_TOKEN to a JWT bot token)" if exc.code == 401 else ""
+        )
+        print(
+            f"openmetadata: search failed ({exc.code} {exc.reason}){hint} — "
+            "skipping lineage source.",
+            file=sys.stderr,
+        )
+        return {"systems": [], "flows": []}
+    except (error.URLError, OSError, ValueError) as exc:
+        print(f"openmetadata: search failed ({exc}) — skipping lineage source.", file=sys.stderr)
+        return {"systems": [], "flows": []}
+    edges = cross_system_edges(client, tables)
+    return build_flow_slice(base, edges)

--- a/architecture_maps/c4gen/pages.py
+++ b/architecture_maps/c4gen/pages.py
@@ -239,14 +239,21 @@ actual client/route code before treating it as a real runtime dependency.
 def _candidate_rows(candidates: list[Flow]) -> str:
     if not candidates:
         return "_None extracted._"
-    rows = ["| Consumer → Provider | Contract sample | Source of truth |",
-            "| --- | --- | --- |"]
+    rows = ["| Consumer → Provider | Source | Contract / lineage | Source of truth |",
+            "| --- | --- | --- | --- |"]
     for f in sorted(candidates, key=lambda x: (x.source, x.target)):
         url = f.provenance.url()
-        loc = f"[{f.provenance.path}]({url})" if url and f.provenance.path else (
-            f"`{f.provenance.path}`" if f.provenance.path else "—"
-        )
+        if f.provenance.asset_fqn:
+            label = f.provenance.asset_fqn.split(".")[-1]
+            loc = f"[{label}]({url})" if url else f"`{label}`"
+        elif url and f.provenance.path:
+            loc = f"[{f.provenance.path}]({url})"
+        elif f.provenance.path:
+            loc = f"`{f.provenance.path}`"
+        else:
+            loc = "—"
         rows.append(
-            f"| {f.source} → {f.target} ({f.label}) | `{f.provenance.contract_key or ''}` | {loc} |"
+            f"| {f.source} → {f.target} ({f.label}) | {f.provenance.derived_from} "
+            f"| `{f.provenance.contract_key or ''}` | {loc} |"
         )
     return "\n".join(rows)

--- a/architecture_maps/c4gen/schema.py
+++ b/architecture_maps/c4gen/schema.py
@@ -16,9 +16,9 @@ Design notes
 * ``Flow.sync`` is the synchronous/asynchronous distinction the brief asks for.
   C4/Mermaid has no native async marker, so the renderer encodes it in the
   relationship's technology slot and the legend documents the convention.
-* ``provenance`` records *how* an edge was learned (graph | code | infra) and,
-  when from the graph, the contract that backs it — so a reader can trust and
-  trace every line.
+* ``provenance`` records *how* an edge was learned (graph | code | infra |
+  openmetadata) and, when from a deterministic source, the contract/asset that
+  backs it — so a reader can trust and trace every line.
 """
 
 from __future__ import annotations
@@ -42,19 +42,39 @@ class NodeKind(StrEnum):
 
 
 class Provenance(Base):
-    """How a flow/node was discovered — drives trust and the "source of truth" link."""
+    """How a flow/node was discovered — drives trust and the "source of truth" link.
 
-    derived_from: Literal["graph", "code", "infra", "manual"] = "manual"
+    ``derived_from`` reserves the vocabulary of deterministic sources:
+
+    * ``graph`` — the witan-code cross-repo code graph (see ``extract.py``);
+      ``contract_*`` and the ``repo``/``path``/``line`` ref back the edge.
+    * ``openmetadata`` — table/asset lineage from the OpenMetadata catalog (see
+      ``openmetadata.py``). The asset that backs the edge is carried as the
+      ``asset_fqn`` (and ``asset_url`` deep-links into the catalog UI);
+      ``contract_kind`` is ``lineage`` and ``contract_key`` names the lineage
+      mechanism reported by OpenMetadata (e.g. ``DbtLineage``).
+    * ``infra`` / ``code`` / ``manual`` — curated or infra-derived.
+    """
+
+    derived_from: Literal["graph", "openmetadata", "code", "infra", "manual"] = "manual"
     # When derived_from == "graph": the cross-repo contract backing this edge.
-    contract_kind: Literal["endpoint", "env_var", "service", "package"] | None = None
+    # When derived_from == "openmetadata": contract_kind == "lineage" and
+    # contract_key names the lineage source (DbtLineage / ViewLineage / ...).
+    contract_kind: Literal["endpoint", "env_var", "service", "package", "lineage"] | None = None
     contract_key: str | None = None
     # A clickable source-of-truth location (repo-relative path + optional line).
     repo: str | None = None
     path: str | None = None
     line: int | None = None
+    # OpenMetadata provenance: the catalog asset the edge was learned from and a
+    # deep link into the catalog UI, so a reader can trace the lineage edge.
+    asset_fqn: str | None = None
+    asset_url: str | None = None
 
     def url(self) -> str | None:
-        """GitHub blob URL for the source ref, when enough is known."""
+        """A clickable source-of-truth URL: GitHub blob, or the catalog asset."""
+        if self.asset_url:
+            return self.asset_url
         if not (self.repo and self.path):
             return None
         base = self.repo.rstrip("/")

--- a/docs/application_specific_guides/mit-learn/architecture/dependencies-and-cycles.md
+++ b/docs/application_specific_guides/mit-learn/architecture/dependencies-and-cycles.md
@@ -5,7 +5,7 @@
      See architecture_maps/README.md. -->
 # Dependencies & Cycles — MIT Learn
 
-_Generated 2026-06-23 20:11 UTC · c4gen dev_
+_Generated 2026-06-23 21:01 UTC · c4gen dev_
 
 Coupling between MIT Learn and the rest of the SOA. The **matrix** and
 **cycles** below come from the deterministic witan-code graph extraction; the
@@ -36,11 +36,11 @@ actual client/route code before treating it as a real runtime dependency.
 
 ## Candidate edges (graph-derived, unverified)
 
-| Consumer → Provider | Contract sample | Source of truth |
-| --- | --- | --- |
-| micromasters → mit-learn (calls 1 endpoint) | `/api/v0/profiles/${userUsername}/` | [static/js/lib/api.js](https://github.com/mitodl/micromasters/blob/main/static/js/lib/api.js) |
-| mit-learn → mitxonline (calls 9 endpoints) | `/api/v0/baskets/, /api/v0/users/${username}/, /api/v0/users/me/` | [load_testing/backend/client/v0/api.ts](https://github.com/mitodl/mit-learn/blob/main/load_testing/backend/client/v0/api.ts) |
-| mitxonline → mit-learn (calls 1 endpoint) | `/api/v0/users/me/` | [frontend/public/src/lib/queries/users.js](https://github.com/mitodl/mitxonline/blob/main/frontend/public/src/lib/queries/users.js) |
+| Consumer → Provider | Source | Contract / lineage | Source of truth |
+| --- | --- | --- | --- |
+| micromasters → mit-learn (calls 1 endpoint) | graph | `/api/v0/profiles/${userUsername}/` | [static/js/lib/api.js](https://github.com/mitodl/micromasters/blob/main/static/js/lib/api.js) |
+| mit-learn → mitxonline (calls 9 endpoints) | graph | `/api/v0/baskets/, /api/v0/users/${username}/, /api/v0/users/me/` | [load_testing/backend/client/v0/api.ts](https://github.com/mitodl/mit-learn/blob/main/load_testing/backend/client/v0/api.ts) |
+| mitxonline → mit-learn (calls 1 endpoint) | graph | `/api/v0/users/me/` | [frontend/public/src/lib/queries/users.js](https://github.com/mitodl/mitxonline/blob/main/frontend/public/src/lib/queries/users.js) |
 
 ## Fragile / noteworthy linkages
 


### PR DESCRIPTION
## What

Adds OpenMetadata catalog lineage as a **second deterministic source** for `c4gen`, parallel to the witan-code code-graph bridge. Lets the extractor see warehouse/ETL data flows that endpoint-contract matching cannot.

- New `architecture_maps/c4gen/openmetadata.py`: queries the OpenMetadata REST API (the data the catalog MCP fronts) for table assets + lineage, maps them into the same `{systems, flows}` slice the renderer already merges.
- `extract`/`build` gain `--source {graph,openmetadata,both}` (default `graph`, so existing runs are unchanged).
- `Provenance` gains `derived_from="openmetadata"`, `contract_kind="lineage"`, and `asset_fqn`/`asset_url` (catalog deep link); the dependencies-page candidate table gains a **Source** column distinguishing `graph` vs `openmetadata`.
- Lineage→system attribution uses the warehouse `<layer>__<source-system>__…` naming; a candidate edge is emitted where a downstream table's upstream spans 2+ source systems, or a `combined` model feeds a synthetic `ol-data-platform` node.

## Validation

- Validated against the **live** OpenMetadata 1.13.0 server; cross-system attribution verified on a captured `marts__combined__orders` lineage payload.
- Graceful degradation: with no bot JWT the source returns an empty slice (logged skip), so `--source openmetadata`/`both` never break a run.
- `render mit-learn` no regression; `extract --help` shows the new option; `ruff` clean.

## Open questions for review (not blockers)

1. **`.graph.yaml` collision**: `--source openmetadata` overwrites the same slice file as graph; `--source both` is the safe refresh. A separate `<system>.lineage.yaml` would be cleaner — left scoped.
2. **System-id map**: `SOURCE_SYSTEM_IDS` (token→system-id) is hardcoded; confirm ids match curated models + the ol-data-platform map.
3. **Auth**: needs a JWT bot token provisioned for CI/live (REST path); env vars `C4GEN_OPENMETADATA_URL`/`C4GEN_OPENMETADATA_TOKEN`.
4. **Tests**: repo has no pytest harness; validated via inline runs against captured live data. Can add pytest to the c4gen group if wanted.

Unblocks the ol-data-platform C4 map (Wave 2), which uses this lineage source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)