### PR TITLE
fix(docs): load C4 diagrams under the System Architecture section

### DIFF
--- a/docs/javascripts/c4-zoom.js
+++ b/docs/javascripts/c4-zoom.js
@@ -16,8 +16,7 @@
   function onArchPage() {
     // Architecture pages live under /system_architecture/; also match a nested
     // /architecture/ segment for backward compatibility with the prior layout.
-    var p = location.pathname;
-    return p.indexOf("/system_architecture/") !== -1 || p.indexOf("/architecture/") !== -1;
+    return /\/(system_)?architecture\//.test(location.pathname);
   }
 
   function enhance(box) {

--- a/docs/javascripts/c4-zoom.js
+++ b/docs/javascripts/c4-zoom.js
@@ -8,13 +8,16 @@
  *   - wraps it in a fixed-height, resizable pan/zoom viewport (svg-pan-zoom),
  *   - navigates on a click of a native PlantUML `$link` (drag-guarded).
  *
- * Scoped to /architecture/ pages.
+ * Scoped to the System Architecture section.
  */
 (function () {
   "use strict";
 
   function onArchPage() {
-    return location.pathname.indexOf("/architecture/") !== -1;
+    // Architecture pages live under /system_architecture/; also match a nested
+    // /architecture/ segment for backward compatibility with the prior layout.
+    var p = location.pathname;
+    return p.indexOf("/system_architecture/") !== -1 || p.indexOf("/architecture/") !== -1;
   }
 
   function enhance(box) {


### PR DESCRIPTION
## Problem
After PR #42 moved the C4 pages to `/system_architecture/<system>/`, the diagrams stopped rendering — the page areas are blank.

## Cause
`docs/javascripts/c4-zoom.js` (which fetches each page's `data-c4-svg` SVG and injects it client-side) is gated on `onArchPage()`:
```js
return location.pathname.indexOf("/architecture/") !== -1;
```
The new URLs contain `_architecture` (in `system_architecture`), not the `/architecture/` path segment, so the guard returns false and `scan()`/`init()` bail before injecting any SVG.

## Fix
Match `/system_architecture/` (and keep the legacy `/architecture/` check). One-line guard change; no generated content affected.

## Verification
- Built JS contains the updated guard.
- A diagram page's `data-c4-svg="../_diagrams/system-context.svg"` resolves to `system_architecture/mit-learn/_diagrams/system-context.svg`, which exists (43 KB); landscape SVG present.
- `zensical build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)