### PR TITLE
chore(docs): cache-bust C4 diagram JS with content-hash fingerprints

### DIFF
--- a/.github/workflows/c4-validation.yml
+++ b/.github/workflows/c4-validation.yml
@@ -15,6 +15,10 @@ on:
     paths:
       - architecture_maps/**
       - docs/system_architecture/**
+      # The cache-bust ?v= check reads mkdocs.yml + hashes these JS assets, so a
+      # PR touching only one of them must still trigger this workflow.
+      - mkdocs.yml
+      - docs/javascripts/**
       - .github/workflows/c4-validation.yml
 
 jobs:

--- a/.github/workflows/c4-validation.yml
+++ b/.github/workflows/c4-validation.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
+      - name: Verify JS cache-bust fingerprints
+        run: python3 architecture_maps/scripts/update_asset_versions.py --check
+
       - name: Wait for Kroki
         run: |
           for i in $(seq 1 30); do

--- a/architecture_maps/scripts/update_asset_versions.py
+++ b/architecture_maps/scripts/update_asset_versions.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Stamp/verify cache-busting ``?v=<sha256[:8]>`` fingerprints on the C4 docs JS.
+
+The C4 diagram JS (``docs/javascripts/*.js``) is referenced from ``mkdocs.yml``'s
+``extra_javascript`` by a stable filename, so a change is served stale by the
+browser/CDN until the TTL lapses or someone purges. Appending a content-hash
+query (``?v=...``) makes each change a new URL that is fetched fresh.
+
+Usage (from the repo root):
+    python architecture_maps/scripts/update_asset_versions.py           # rewrite ?v= in place
+    python architecture_maps/scripts/update_asset_versions.py --check   # CI: exit 1 if any stale
+
+Zero third-party deps so CI can run it with a bare ``python3``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MKDOCS = REPO_ROOT / "mkdocs.yml"
+DOCS_DIR = REPO_ROOT / "docs"
+
+# Matches an extra_javascript list entry pointing at a local javascripts/*.js
+# asset, with an optional existing ?v=<hash>. Quote-agnostic, trailing space ok.
+_ENTRY = re.compile(
+    r'(?P<lead>-\s*)(?P<path>javascripts/\S+?\.js)(?:\?v=(?P<ver>[0-9a-f]+))?(?P<tail>[ \t]*)$',
+    re.MULTILINE,
+)
+
+
+def _fingerprint(asset_path: str) -> str:
+    f = DOCS_DIR / asset_path
+    if not f.is_file():
+        raise FileNotFoundError(f"referenced asset not found: {f.relative_to(REPO_ROOT)}")
+    return hashlib.sha256(f.read_bytes()).hexdigest()[:8]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help="verify committed ?v= matches each asset's content hash; exit 1 if not",
+    )
+    args = ap.parse_args()
+
+    text = MKDOCS.read_text(encoding="utf-8")
+    stale: list[str] = []
+
+    def repl(m: re.Match[str]) -> str:
+        want = _fingerprint(m.group("path"))
+        have = m.group("ver")
+        if have != want:
+            stale.append(f"{m.group('path')}: committed v={have or '(none)'} expected v={want}")
+        return f"{m.group('lead')}{m.group('path')}?v={want}{m.group('tail')}"
+
+    updated = _ENTRY.sub(repl, text)
+
+    if not _ENTRY.search(text):
+        print("no local javascripts/*.js entries found in mkdocs.yml extra_javascript", file=sys.stderr)
+        return 1
+
+    if args.check:
+        if stale:
+            print("STALE asset cache-bust fingerprints (regenerate with this script, no --check):")
+            for s in stale:
+                print(f"  - {s}")
+            return 1
+        print("OK: all extra_javascript ?v= fingerprints match their file content.")
+        return 0
+
+    if updated != text:
+        MKDOCS.write_text(updated, encoding="utf-8")
+        print("Updated cache-bust fingerprints:")
+        for s in stale:
+            print(f"  - {s}")
+    else:
+        print("No changes — fingerprints already current.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/architecture_maps/scripts/update_asset_versions.py
+++ b/architecture_maps/scripts/update_asset_versions.py
@@ -28,7 +28,8 @@ DOCS_DIR = REPO_ROOT / "docs"
 # Matches an extra_javascript list entry pointing at a local javascripts/*.js
 # asset, with an optional existing ?v=<hash>. Quote-agnostic, trailing space ok.
 _ENTRY = re.compile(
-    r'(?P<lead>-\s*)(?P<path>javascripts/\S+?\.js)(?:\?v=(?P<ver>[0-9a-f]+))?(?P<tail>[ \t]*)$',
+    r'(?P<lead>-\s*(?P<q>["\']?))(?P<path>javascripts/\S+?\.js)'
+    r'(?:\?v=(?P<ver>[0-9a-f]+))?(?P<tail>(?P=q)[ \t]*)$',
     re.MULTILINE,
 )
 
@@ -59,10 +60,14 @@ def main() -> int:
             stale.append(f"{m.group('path')}: committed v={have or '(none)'} expected v={want}")
         return f"{m.group('lead')}{m.group('path')}?v={want}{m.group('tail')}"
 
-    updated = _ENTRY.sub(repl, text)
-
     if not _ENTRY.search(text):
         print("no local javascripts/*.js entries found in mkdocs.yml extra_javascript", file=sys.stderr)
+        return 1
+
+    try:
+        updated = _ENTRY.sub(repl, text)
+    except FileNotFoundError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
         return 1
 
     if args.check:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,8 +24,12 @@ extra_css:
 extra_javascript:
   # Pan/zoom for the C4 architecture diagrams (drill-down is native PlantUML
   # links). svg-pan-zoom is vendored and loaded before c4-zoom.js.
-  - javascripts/vendor/svg-pan-zoom.min.js
-  - javascripts/c4-zoom.js
+  # The ?v= is the file's sha256[:8] — a cache-busting fingerprint so a JS change
+  # is served fresh (browser + CDN) instead of stale. Regenerate after editing
+  # either file with: python architecture_maps/scripts/update_asset_versions.py
+  # (CI fails via --check if a committed ?v= doesn't match the file's content.)
+  - javascripts/vendor/svg-pan-zoom.min.js?v=f4637103
+  - javascripts/c4-zoom.js?v=c53b4ad7
 nav:
   - Home: index.md
   - Getting Started & How-Tos:


### PR DESCRIPTION
## Problem
The C4 diagram JS (`c4-zoom.js`, `svg-pan-zoom.min.js`) is referenced by stable filenames in `extra_javascript`, so a change is served **stale** by the browser/Fastly until the TTL lapses or someone manually purges — exactly what made the System Architecture path fix (#43) invisible on the live site until the cache dropped.

## Fix
- Append `?v=<sha256[:8]>` content fingerprints to the JS URLs in `mkdocs.yml`, so each change is a new URL fetched fresh by browser + CDN.
- `architecture_maps/scripts/update_asset_versions.py` (zero-dep stdlib) (re)stamps the fingerprints; run it after editing the JS.
- A `c4-validation` CI step runs it with `--check`, so a JS change **without** a version bump fails CI — deploys are self-busting from here on.

## Verification
- Built HTML emits `<script src=".../c4-zoom.js?v=c53b4ad7">`.
- Script: OK on clean, idempotent, **exits 1 on simulated drift** (reports the expected new hash).
- `zensical build` + `ruff` clean.

Closes `tk-cache-bust-c4gen-js-assets-...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)