### PR TITLE
fix(c4gen): filter phantom cross-repo edges by witan-code confidence

### DIFF
--- a/architecture_maps/c4gen/extract.py
+++ b/architecture_maps/c4gen/extract.py
@@ -102,14 +102,29 @@ class Contract:
     consumer_ref: dict[str, dict] = field(default_factory=dict)
 
 
-def group_contracts(rows: list[dict]) -> dict[tuple[str, str], Contract]:
+def group_contracts(rows: list[dict], min_confidence: float = 0.5) -> dict[tuple[str, str], Contract]:
+    """Group bindings into per-``(kind, key_norm)`` contracts.
+
+    Low-confidence endpoint *consumer* bindings (``confidence < min_confidence``)
+    are dropped: these are the phantom-prone signals witan-code scores down —
+    k6/load-test clients, same-origin CSRF/relative fetches, and self-provided
+    routes. Providers and non-endpoint consumers are always kept. A missing
+    ``confidence`` (legacy store rows, pre the witan-code schema add) is treated
+    as 1.0 (kept) — note ``confidence`` may be 0.0, so test ``is None`` explicitly
+    rather than truthiness.
+    """
     groups: dict[tuple[str, str], Contract] = {}
     for b in rows:
+        role = b["role"]
+        if role != "provider" and b["kind"] == "endpoint":
+            conf = b.get("confidence")
+            if conf is not None and conf < min_confidence:
+                continue
         key = (b["kind"], b["key_norm"])
         c = groups.get(key)
         if c is None:
             c = groups[key] = Contract(b["kind"], b.get("key", b["key_norm"]), b["key_norm"])
-        if b["role"] == "provider":
+        if role == "provider":
             c.providers.add(b["repo"])
         else:
             c.consumers.add(b["repo"])


### PR DESCRIPTION
## What
c4gen's `extract.cross_repo_edges` reads the witan-code bridge but applied **no precision filter**, so the deterministic extractor surfaced the 3 known phantom candidate edges (k6 load-test client, same-origin CSRF fetches, self-provided `/users/me`) and a false `mit-learn↔mitxonline` cycle.

`group_contracts` now drops endpoint **consumer** bindings with `confidence < min_confidence` (default 0.5) — consuming the confidence score the bridge now persists + projects (agent-kit `ab7edd4`). Providers and non-endpoint consumers are always kept; missing `confidence` ⇒ 1.0 (checked `is None`, not truthiness — `confidence` can be `0.0`).

## Verification
Against the migrated + reindexed bridge store, `c4gen extract` for mit-learn / mitxonline / micromasters now yields **0 cross-service flows, 0 cycles** (was 3 phantoms + 1 false cycle). `cycles.json` → `[]`. ruff clean. Committed maps are unaffected (they never drew the phantoms; graph slices aren't committed).

## Scope note
This closes the **precision** half of `tk-fix-c4gen-extract-scope-...`. The task's other two items — per-**system-scoping** of the candidate slice (extract still writes a global slice to every `<name>.graph.yaml`) and **broadening beyond `endpoint` contracts** (service/env-var/ETL flows) — remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)