### PR TITLE
fix(c4gen): scope extract candidate slice + cycles to the model's system

### DIFF
--- a/architecture_maps/c4gen/cli.py
+++ b/architecture_maps/c4gen/cli.py
@@ -101,11 +101,23 @@ def _merge_systems(curated: dict, slice_: dict) -> dict:
 
 @app.command
 def extract(name: str) -> None:
-    """Refresh the deterministic cross-service slice for model ``name`` from the graph."""
+    """Refresh the deterministic cross-service slice for model ``name`` from the graph.
+
+    Scoped to ``name``: the slice carries only cross-service candidate edges that
+    its ``meta.primary_system`` consumes or provides, and only cycles that system
+    participates in — not the whole-SOA edge set (which was previously written
+    identically to every ``<name>.graph.yaml``).
+    """
+    curated = _load_yaml(MODELS_DIR / f"{name}.yaml")
+    primary = (curated.get("meta") or {}).get("primary_system") or name
+
     rows = extract_mod.load_bindings()
     contracts = extract_mod.group_contracts(rows)
-    edges = extract_mod.cross_repo_edges(contracts, kinds=("endpoint",))
-    cycles = extract_mod.find_cycles(edges)
+    all_edges = extract_mod.cross_repo_edges(contracts, kinds=("endpoint",))
+    # Cycles are detected over the FULL edge set (so multi-hop cycles routed
+    # through the primary aren't lost), then filtered to ones it is part of.
+    cycles = [c for c in extract_mod.find_cycles(all_edges) if primary in c]
+    edges = extract_mod.edges_incident_to(all_edges, primary)
     slice_ = extract_mod.build_flow_slice(edges)
 
     MODELS_DIR.mkdir(parents=True, exist_ok=True)

--- a/architecture_maps/c4gen/extract.py
+++ b/architecture_maps/c4gen/extract.py
@@ -204,6 +204,17 @@ def find_cycles(edges: list[CrossEdge]) -> list[list[str]]:
     return [list(c) for c in sorted(cycles)]
 
 
+def edges_incident_to(edges: list[CrossEdge], system: str) -> list[CrossEdge]:
+    """Keep only edges where ``system`` (a system id, e.g. ``mit-learn``) is the
+    consumer or provider.
+
+    Scopes a model's graph slice to its OWN cross-service candidates instead of
+    the whole-SOA edge set, so each ``<name>.graph.yaml`` and its rendered
+    Dependencies page carry only edges that system participates in.
+    """
+    return [e for e in edges if system in (system_id(e.src), system_id(e.dst))]
+
+
 def build_flow_slice(edges: list[CrossEdge]) -> dict:
     """Turn cross-repo edges into a serializable ``Model``-shaped dict (systems + flows)."""
     systems: dict[str, dict] = {}


### PR DESCRIPTION
## What
`extract(name)` computed the whole-SOA cross-repo edge set and wrote a **byte-identical** slice to every `<name>.graph.yaml` (it ignored `name` except for the output filename). So each system's *Dependencies & Cycles* page would surface all SOA candidate edges and every cycle — e.g. a `micromasters → mit-learn` edge and the `mit-learn↔mitxonline` cycle on the **ODL Video Service** page.

Now scoped to the model's `meta.primary_system`:
- new `extract.edges_incident_to(edges, system)` keeps only edges the system consumes/provides;
- cycles are detected over the **full** edge set (so multi-hop cycles routed through the primary aren't lost) then filtered to ones the system participates in.

## Verification
Against the unfiltered edge set (phantoms present, to exercise scoping):
| system | incident edges | cycles |
|---|---|---|
| mit-learn | 3 | `[mit-learn, mitxonline]` |
| mitxonline | 2 | `[mit-learn, mitxonline]` |
| micromasters | 1 | — |
| ocw-studio | 0 | — |

Previously every system got the identical global slice. With the production confidence filter (PR #47) the SOA yields 0 edges either way. `ruff` clean; graph slices aren't committed so no doc churn.

## Scope
Completes the **per-system-scoping** defect of `tk-fix-c4gen-extract-scope-...`. The **precision** half shipped in #47; the **breadth-beyond-`endpoint`** item is moved to the OpenMetadata lineage task (OpenMetadata is the reliable source for ETL/warehouse cross-service flows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)