### PR TITLE
feat: integrate Engineering Handbook, add top-level nav tabs

### DIFF
--- a/docs/handbook/delivering/code-review.md
+++ b/docs/handbook/delivering/code-review.md
@@ -1,0 +1,105 @@
+# Code Review
+A guide for reviewing code and having your code reviewed.
+
+> Peer code reviews are the single biggest thing you can do to improve your code - [Jeff Atwood](http://blog.codinghorror.com/code-reviews-just-do-it/)
+
+# Purpose
+Code review is an important part of a team's development process. It helps to:
+
+* disseminate knowledge about the codebase/technology/techniques across teams
+* increase awareness of the features being developed
+* provide opportunities to educate junior engineers (actually all engineers)
+* find alternative solutions to problems
+* catch poor architectural decisions and bugs
+* develop a sense of team ownership of the code (no more his/her code)
+
+When doing code reviews, **the process is as important as the result**, therefore, some guidelines are presented below to help improve the process of code review.
+
+# Everyone
+* Accept that many programming decisions are opinions. Discuss tradeoffs, which
+you prefer, and reach a resolution quickly.
+* Ask questions; don't make demands. ("What do you think about naming this
+`:user_id`?")
+* Ask for clarification. ("I didn't understand. Can you clarify?")
+* Avoid selective ownership of code. ("mine", "not mine", "yours")
+* Avoid using terms that could be seen as referring to personal traits. ("dumb",
+"stupid"). Assume everyone is attractive, intelligent, and well-meaning.
+* Be explicit. Remember people don't always understand your intentions online.
+* Be humble. ("I'm not sure - let's look it up.")
+* Don't use hyperbole. ("always", "never", "endlessly", "nothing")
+* Don't use sarcasm.
+* Talk in person if there are too many "I didn't understand" or "Alternative
+solution:" comments. Post a follow-up comment summarizing offline discussion.
+
+# Having Your Code Reviewed
+* Review your code before anybody else.
+* Provide context about what the change is and why is it important - Write informative commit messages [4] and pull request descriptions.
+* Use the pull request description template [3]. You only need to answer the relevant questions. Pro tip: use the bookmarklet [11] or chrome extension [12] for pull request description templates.
+* Annotate your code reviews. Add comments anywhere that you feel will help the reviewer understand your code.
+* Be grateful for the reviewer's suggestions. ("Good call. I'll make that
+change.")
+* Don't take it personally. The review is about the code, not you.
+* Explain why the code exists. ("It's like that because of these reasons. Would
+it be more clear if I rename this class/file/method/variable?")
+* Seek to understand the reviewer's perspective.
+* Respond to every comment. If you can't or won't change something, let the reviewers know why.
+* Wait to merge the branch until someone has :+1:'d your PR and Continuous Integration
+tells you the test suite is green in the branch.
+* Merge once you feel confident in the code and its impact on the project.
+* Delete the backing branch.
+
+# Reviewing Code
+* Code review often and for short sessions. The effectiveness of code review drops after around an hour. Set aside time throughout your day to coincide with breaks in order to not disrupt your flow.
+* Review at least part of the code, even if you can't do all of it. If you can't do all of it, comment on the PR to indicate this, so the author can get a full review.
+* Review the right things, let tools to do the rest. Don't focus on reviewing things that can be reviewed by tools (e.g. eslint, pylint, etc). If the tools don't provide good feedback, change the config or improve the tools.
+
+Understand why the code is necessary (bug, user experience, refactoring). Then:
+
+* Communicate which ideas you feel strongly about and those you don't.
+* Identify ways to simplify the code while still solving the problem.
+* If discussions turn too philosophical or academic, move the discussion offline. In the meantime, let the
+author make the final decision on alternative implementations.
+* Offer alternative implementations, but assume the author already considered
+them. ("What do you think about using a custom validator here?")
+  * If possible, use GitHub's suggestion feature to propose specific changes to a line or two of code.
+  * If you want to propose a complex alternative, discuss with the author first, then consider opening a PR with your changes that targets the PR you are reviewing. Don't add commits directly to the branch you are reviewing. This helps to prevent misunderstandings and merge conflicts.
+* Seek to understand the author's perspective.
+* Sign off on the pull request with a :thumbsup: or "Ready to merge" comment... always!
+* Compliment/reinforce good practices.
+
+Some suggestions of things to look for when reviewing code:
+
+* Does the code work? Does it perform its intended function, the logic is correct etc.
+* Is all the code easily understood? Is code unnecessarily complex ?
+* Can variable/method names be improved?
+* Are classes/files/methods becoming too large? Should they be split into smaller pieces?
+* Does it conform to the agreed coding conventions?
+* Is there any redundant or duplicate code? Is the code as modular as possible?
+* Could the design of the solution be improved (e.g. single responsibility principle, open/closed principle) ?
+* Is the code testable? (i.e. class design is such that you can easily mock dependencies, etc)
+* Are there tests? It's not enough to be testable, code should be tested.
+* Things related to your area of expertise
+
+Pro tip: Keep your own checklist of things you look for in a code review as in [9] [7].
+
+# Links
+Links from places on the Internet that helped write this:
+
+(The most useful ones are [9], [1], [3] and [2].)
+
+* [1] [Talk - Implementing a Strong Code-Review culture](https://www.youtube.com/watch?v=PJjmw9TRB7s) - the talk that inspired this.
+* [2] [Thoughtbot's Guide for Code-Review](https://github.com/thoughtbot/guides/blob/master/code-review/README.md) - straight to the point guidelines on code review. A lot of the content was taken from there.
+* [3]  [Pull request templates make code review easier](https://quickleft.com/blog/pull-request-templates-make-code-review-easier/) - introduction to pull request templates.
+* [4] some articles on how to write good commit messages - [first](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html), [second](http://www.slideshare.net/TarinGamberini/commit-messages-goodpractices),  [third](https://wiki.openstack.org/wiki/GitCommitMessages)
+* [5] [Am I My Code?](http://mfeckie.github.io/Am-I-My-Code/) - this article explores some strategies for giving feedback when reviewing code.
+* [6] [Code review at the Dropbox iOS team](http://www.objc.io/issue-22/dropbox.html) - the article goes over their whole process of review. It has some interesting ideas.
+* [7] [Code Review Checklist](http://blog.fogcreek.com/increase-defect-detection-with-our-code-review-checklist-example/) - from Fog Creek Software
+* [8] [Effective code review tips](http://blog.fogcreek.com/effective-code-reviews-9-tips-from-a-converted-skeptic/) - from Fog Creek Software
+* [9] [Code Review Best Practices](http://kevinlondon.com/2015/05/05/code-review-best-practices.html) - really good article on code review best practices
+* [10] [11 proven practices to improve code reviews](http://www.ibm.com/developerworks/rational/library/11-proven-practices-for-peer-review/) - nice article backed by data from studies.
+* [11] [Pull request template bookmarklet](https://quickleft.com/blog/pull-request-template-bookmarklet/)
+* [12] [Pull request template chrome extension](https://github.com/sprintly/pull-request-template-chrome-extension)
+
+
+Thanks to @marionzualo for compiling this list.
+https://gist.github.com/marionzualo/82fbf4e3d20ef253d3ef

--- a/docs/handbook/delivering/development-process.md
+++ b/docs/handbook/delivering/development-process.md
@@ -1,0 +1,162 @@
+# Development Process
+An approximate workflow guide to hacking on software at the MIT Office of Digital Learning.
+
+# Purpose
+Every team of developers has its own particular approach to writing, reviewing, and deploying code.
+This guide aims to capture MIT ODL's way of doing things. It will be (hopefully) useful as a
+step-by-step guide for new developers.
+
+# Tools
+
+- git
+- Zenhub Chrome extension (https://www.zenhub.io/)
+  - This extension adds the **Boards** and **Burndown** tabs to GitHub repos. We use it in the way
+  that you might use JIRA or Trello. The **Boards** tab is particularly important as it adds a
+  'swim lane'-type view for open issues.
+
+# Coding Workflow
+
+
+### Step 0) Choosing or creating an Issue for work to be done
+
+Before starting work, we prefer to have an issue logged in Github. If you don't have an issue assigned
+to yourself, the open issues for the current sprint should be in the "Ready" column of the "Boards"
+tab. You can pick one up by assigning it to yourself and moving it to "In Progress". If there isn't
+an issue for the work you have in mind, you can click "New Issue" in the "Boards" or "Issues" tabs.
+A detailed description with accurate tags are much appreciated.
+
+### Step 1) Hacking
+
+#### &#10146; Clone the given Repository from GitHub
+
+Example: `git clone http://github.com/mitodl/micromasters.git`
+
+#### &#10146; Create a Branch for the given issue
+
+Assuming you're working on issue **#123** in GitHub, you create a new branch from master/main like so:
+
+    git checkout -b NEW-BRANCH_NAME origin/master
+
+Eventually you'll want to push this new branch to origin to make it available to other developers.
+You can do this before you open a Pull Request (see below) or right after you create the branch:
+
+    git push -u origin NEW-BRANCH_NAME
+
+#### &#10146; Hack away!
+
+Make changes, test (automated and/or manual), commit, repeat. The repo README should have details
+for running automated tests.
+
+
+### Step 2) Code Review
+
+_When you've completed the given issue, the code is passing tests, and you feel like it's ready
+to ship, it's time to start code review. Make sure you read through the
+[Code Review guide](https://github.com/mitodl/handbook/blob/master/code-review.md#everyone) to get a sense
+about why we do code reviews and how to approach them, both as a reviewer and reviewee._
+
+#### &#10146; Open a Pull Request ("PR")
+
+This can be kicked off from several places in GitHub. The easiest one to remember is the "New
+Pull Request" button in your repo's "Pull Requests" tab
+([example](https://github.com/mitodl/micromasters/pulls)). Your **base** branch should be
+**master/main** and your **compare** branch should be your issue branch.
+
+When you first open the PR, the input should be pre-populated with a
+PR template. Each project has its own template, but it should look roughly like [this](https://github.com/mitodl/handbook/blob/master/pr-template.md). Fill in every section
+that is relevant to your PR, and delete the sections that aren't relevant. Under the **"relevant
+tickets"** section, be sure to indicate the issue that you're fixing. GitHub will automatically
+link to your issue if you type '#' followed by your issue number (and it will help you with an
+autocomplete menu). **If your PR is intended to fix/close an issue (typically true), fill in this
+section with "fixes #123" or "closes #123".** When your PR is eventually merged, this text is
+parsed, and the issue will be automatically closed if "fixes #X"/"closes #X" is found.
+
+Before (or after) you submit the PR, add the "Needs Review" label to it.
+
+
+**TL;DR**
+
+1. Click "New Pull Request"
+1. Fill in (or confirm) the appropriate **base** and **compare** branches
+1. Fill in all the relevant sections in the PR template (especially "relevant tickets", which should
+   typically read "Closes #*ISSUE_NUMBER*" or "Fixes #*ISSUE_NUMBER*")
+1. Add the "Needs Review" label
+1. Submit and wait for comments/approval
+
+#### &#10146; Respond to comments until you get approval
+
+As comments come in and changes are requested, you can make any necessary changes and push them when
+you feel the requests are satisfied.
+
+Reviewers should change the PR's label to "Waiting on author" when they are finished making comments
+and requesting changes. Similarly, when you are finished making changes based on that feedback and
+responding to comments, you should change the label back to "Needs Review".
+
+Right now, we consider a PR to be "approved" if the assigned reviewer on the PR has given you a +1
+(thumbs up). Use your own discretion about seeking out further approvals. That might be appropriate
+if there is someone very familiar with the code you're working on, but isn't the assigned reviewer.
+
+In the unlikely event of a disagreement that can't be resolved, the final decision should be taken by
+the developer and not the reviewer. Again, you should read the
+[Code Review guide](https://github.com/mitodl/handbook/blob/master/code-review.md#everyone), which has
+some advice on avoiding this kind of unresolvable disagreement.
+
+**TL;DR**
+
+- Make changes/respond to comments as needed and reset the PR label to "Needs Review"
+- PR is considered "approved" when you get a +1 (thumbs up) from the assigned reviewer
+
+#### &#10146; (As necessary) Rebase onto master/main and resolve conflicts when they occur
+
+As you work on your PR, changes may be made to master/main that cause would-be merge conflicts. The
+merge-ability of your branch will be indicated near the bottom of your PR page. If conflicts are detected,
+you should rebase your branch onto master/main, fix the conflicts, and push your branch. Here is a [rebasing
+guide maintained by edX](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request). The
+process looks something like this in the command line:
+
+    # Assuming (a) your issue branch is currently checked out...
+    git fetch && git rebase origin/master
+    # Resolve merge conflicts, commit, repeat until done
+    # When merge conflicts are all resolved...
+    git push
+
+That message near the bottom of your PR page should have a green check mark and read "This branch has no
+conflicts with the base branch" when you have successfully resolved and pushed.
+
+
+### Step 3) Merging
+
+#### &#10146; "Squash" the commits on your branch
+
+You may have many incremental commits on your issue branch. In order to keep the git log for the master/main
+branch clean and readable, we "squash" all issue branch commits into one commit before merging. The commit
+message should be a past tense description of your entire PR, eg: "Updated the home page to match new design". Using
+the past tense makes it easier to write coherent release notes.
+
+The actual squashing can be done in a few different ways. The two main approaches are (1) interactive rebase,
+and (2) soft reset. The aforementioned edX rebasing guide contains information about
+[squashing branch commits with an interactive rebase](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request#squash-your-changes).
+This is the recommended method, but you can also try accomplishing this with a soft reset:
+
+    git fetch
+    git merge-base YOUR_BRANCH master
+    # 'merge-base' will give you a commit hash. Copy that value for this next command
+    git reset --soft COMMIT_HASH
+    git commit -am "YOUR_COMMIT_MESSAGE"
+    # The above will cause your branch to diverge, so you'll need force-push.
+    # Make sure your git 'push.default' config is set to 'simple' before running this.
+    git push origin YOUR_BRANCH -f
+
+When this is done, your git log should show one commit for all the changes in your branch followed by the
+'merge base' of your branch.
+
+#### &#10146; Merge your PR into master/main via GitHub
+
+We merge PR's by button-click in GitHub for a few reasons. One of them to avoid possible human error in
+pushing to master/main in the command line. Near the bottom of your PR page, you should see a "Merge pull request"
+button. Click that.
+
+#### &#10146; Delete your branch and move your issue
+
+You should see an option to delete your branch after you merge in GitHub. When the branch is deleted, go to
+the "Boards" tab in your repo and move your issue over to "Done".

--- a/docs/handbook/delivering/environments.md
+++ b/docs/handbook/delivering/environments.md
@@ -1,0 +1,38 @@
+# Environments
+
+- Each environment is deployed independently (e.g. separate servers, DBs, etc).
+- Each environment deploys new code included in the release once the automated tests for that particular release-commit pass successfully.
+
+## Environment Name
+
+|              |                                                      |
+|--------------|------------------------------------------------------|
+| Git Branch   | The Github branch that the environment has deployed. |
+| Purpose      | The purpose of the environment.                      |
+| Expectations | Expectations for environment usage and processes.    |
+
+
+## CI
+
+|              |                                                                                                                                    |
+|--------------|------------------------------------------------------------------------------------------------------------------------------------|
+| Git Branch   | `main` or `master`                                                                                                                 |
+| Purpose      | Testing code from `main` or `master` in a deployed environment prior to being included in a release candidate and release process. |
+| Expectations | Code is tested and functionality confirmed shortly after releasing to CI.                                                          |
+
+
+## RC
+
+|              |                                                                                                                           |
+|--------------|---------------------------------------------------------------------------------------------------------------------------|
+| Git Branch   | `release-candidate`                                                                                                       |
+| Purpose      | Functional testing prior to production deployment.<br/>Acceptance testing by stakeholders.<br/>Demonstration environment. |
+| Expectations | Mock data can be created.  Some risk is acceptable by deploying code that cannot be tested locally by a developer.        |
+
+## Production
+
+|              |                                                                                |
+|--------------|--------------------------------------------------------------------------------|
+| Git Branch   | `release`                                                                      |
+| Purpose      | Environment for end users.                                                     |
+| Expectations | Limit creation of mock data.  Code and functionality should pose minimal risk. |

--- a/docs/handbook/delivering/how-we-work.md
+++ b/docs/handbook/delivering/how-we-work.md
@@ -1,0 +1,89 @@
+# How We Work
+We hire smart and talented people and support them in doing their best work. The core
+component of how we think about "getting work done" is that we trust everyone to take
+ownership of the tasks/features/projects that they are involved in.
+
+In order to ensure that we maintain a common understanding of what is involved in our
+work and a high quality of our output, it is useful to highlight the stages of our work
+and the value that each step provides.
+
+## Project Shaping
+The first step of any project is to understand the scope and goals of the work to be
+done. This typically involves documenting the user-facing value that the work will
+provide and collaborating with product managers to ensure that everyone is properly
+aligned and understands what needs to be done.
+
+## Architecture
+Every piece of functionality for our products has an impact on the architecture of our
+platforms, and the design/experience of our end users. To that end, it is important that
+we have a common understanding of how we are going to build a piece of functionality and
+why we have chosen that approach. For large projects (with “large” being a subjective
+term) we write [Request For Comments
+(RFC)](https://blog.pragmaticengineer.com/scaling-engineering-teams-via-writing-things-down-rfcs/)
+documents that capture our thinking on these questions. These [RFC
+documents](https://github.com/mitodl/hq/discussions/categories/rfc) are then shared
+widely throughout the team to ensure that everyone has the opportunity to provide input
+and learn about the work being done.
+
+## Design
+For visual aspects of our work the RFC may be replaced with a graphic design, a set of
+wireframes, etc. This will provide a way for engineers who will be implementing a
+feature to understand the user flow and provide input on constraints that may influence
+the final design.
+
+## Planning
+At the tactical level, it is necessary to understand the steps required to complete a
+project and the dependencies across those steps. Timely, clear, and effective
+communication is the most important tool in this stage. For small, well understood tasks
+this will most likely mean creating an issue in GitHub to track progress and coordinate
+conversations. For more complex or speculative projects this might mean convening a
+meeting with relevant stakeholders, breaking the task into multiple stages and
+documenting the overarching roadmap, or opening a discussion thread in a shared channel
+(e.g. [GitHub Discussions](https://github.com/mitodl/hq/discussions))
+
+## Implementation
+Once the scope of a problem is understood it is necessary to create a way to deliver the
+intended functionality. This will typically be done through writing code that is
+incorporated into one of our source repositories. Sometimes it will mean using
+third-party services or tools. Maybe it requires something else entirely. As the person
+solving the problem, you are best situated to know how best to bring it to resolution.
+
+For more details on our development process please refer to the guide [here](/delivering/development-process.html).
+
+## Validate
+Once a feature is added to one of our products, we need to ensure that it functions
+properly and will continue to do so. This typically involves writing automated tests
+using one of our selected frameworks. This may also involve writing a manual test plan
+and ensuring that it is executed on a periodic basis.
+
+## Document
+A feature is not useful if nobody knows that it exists or how to use it. In order to
+ensure that we don’t have to explain something more than once, it is necessary to write
+documentation that addresses the needs of our peers and end-users. This documentation
+may take many forms, including but not limited to:
+- In-line code comments that explain the “why” for a given approach
+- Meaningful and descriptive variable, function, and class definitions
+- README documentation that lives with the source code. There is nothing preventing the
+  presence of multiple README documents if it will provide more value to be located
+  closer to the code it addresses.
+- In-line documentation (e.g. docstrings, type annotations, code contracts) that
+  provides detailed information about how and why a given function/class will be
+  used. This allows us to use automated tools (e.g. sphinx) to create documentation
+  sites for our projects.
+- Architecture diagrams, flow charts, sequence diagrams, etc. to visually represent how
+  a project is structured, how logical flows are expected to work, etc.
+
+## Deliver To Production
+While you may not be the person who is actually shipping the functionality into a
+production environment, it is your responsibility to make sure that it happens. This
+includes:
+- Ensuring that you get timely feedback on your pull requests
+- Personally validating functionality, or helping others to validate it for you
+- Working with platform engineering to inform them of any requirements to support your
+  functionality (e.g. “I need a new S3 bucket”, “This will require a Redis database and
+  expanded IAM permissions”, etc.)
+
+For a more comprehensive list of the application level details involved in something
+being ready for production refer to the "[production readiness](/delivering/production-ready.html)"
+guide. The steps involved in getting the code delivered to production are documented in
+the [release process](/delivering/release-process.html) guide.

--- a/docs/handbook/delivering/index.md
+++ b/docs/handbook/delivering/index.md
@@ -1,0 +1,8 @@
+# How We Deliver
+
+- [Code Review](code-review.md)
+- [Development Process](development-process.md)
+- [Environments](environments.md)
+- [How We Work](how-we-work.md)
+- [Production Ready](production-ready.md)
+- [Release Process](release-process/index.md)

--- a/docs/handbook/delivering/production-ready.md
+++ b/docs/handbook/delivering/production-ready.md
@@ -1,0 +1,52 @@
+# Production Ready
+
+This document defines our standard for production ready applications and
+changes from an *operations* standpoint. The point at which the *product* is
+ready can vary highly from project to project.
+
+## Overview
+
+### Applications
+
+At the application scope, we adhere closely to Heroku's
+[Twelve-Factor App](http://12factor.net/) guidelines as a baseline for
+production readiness. The "Production checklist" lists out specific
+implementation guidelines for making applications production ready.
+
+### New code changes
+
+Any time a new changeset is found to impede production readiness (for example,
+a changeset might introduce functionality that, by design, obscures logging or
+fails silently in a production setting), it's not a production ready change,
+and should not be promoted in the release pipeline. Additionally, for any code
+change to become "production ready", it must be verified working in the context
+of a controlled pre-production environment identical to production.
+
+## "Production readiness" checklists
+
+### Required features:
+
+- [ ] Does it support configuration via environment variables?
+- [ ] Does it support configuration via flatfile (e.g. YAML)?
+- [ ] Does it have a sane default configuration (e.g. as close to a realistic production configuration as possible)?
+- [ ] Does it run on parallel HTTP workers? (e.g. uWSGI, Gunicorn)?
+- [ ] Does it log to standard out/error?
+- [ ] Does it log to syslog?
+- [ ] Can it send stack trace emails to a configurable email list?
+- [ ] Does it have configurable log levels (e.g. DEBUG, ERROR, WARNING, INFO)?
+- [ ] Does it have a test suite which measures code coverage?
+- [ ] Does it have a status route (which requires a secret token) that can be used for health checking by a monitoring service?
+- [ ] Does the health check validate that each service the app depends on is reachable (e.g. databases, caching, external APIs when necessary)?
+- [ ] Does the health check return a response body with the availability information above in a machine-readable format in all cases?
+- [ ] Does the health check return a 500 status code when any component in the health check is detected to be failing?
+
+### Required documentation/service infrastructure:
+
+- [ ] Does it have continuous integration builds which run the full test suite?
+- [ ] Does it have an automated continuous delivery to a development environment?
+- [ ] Does it have a documented release process?
+- [ ] Does its release process include staging and production builds, where staging builds are promoted to production?
+- [ ] Does its release process require that code changes be "signed off" as working on staging before being promoted to production?
+- [ ] Does it have application/resource monitoring in production (e.g. New Relic agent, Zenoss SNMP)?
+- [ ] Does it have service availability monitoring in production (e.g. periodic health checks with Zenoss or New Relic)?
+- [ ] Does it have automated, periodically generated, fully restorable backups for each non-ephemeral data store in production?

--- a/docs/handbook/delivering/release-process/index.md
+++ b/docs/handbook/delivering/release-process/index.md
@@ -1,0 +1,39 @@
+# Release Process
+
+## Release Responsibilities
+
+### Communication
+
+Communication around releases is important:
+
+- The main channel for communication around releases is the Slack channel for the product associated with the release.
+- If you won't be available to verify your changes in the RC environment, ask a team member to take over and verify your changes in RC.
+- If a release candidate should not be promoted to the Production environment, identify and communicate the next steps within the Slack channel for the product associated with the release.
+
+### Engineering Team
+
+Collectively the team members who have made changes in a release candidate are responsible for coordinating the release.
+
+### Release Manager
+
+When a new release candidate is created, the role of "release manager" is designated to the engineer who triggered it.
+
+## When can releases happen?
+
+### Release Candidates
+  
+Engineers create release candidates whenever they need to.  Release candidates (releases to the CI and RC environments) can be performed whenever, unless a hold or blocker as been communicated by another team member.  
+
+- Consider the following when there is already a release candidate in progress:
+  - If your changes **aren't** urgent, wait for this release candidate to be completed.
+  - If your changes **are** urgent, communicate with the rest of the team before closing the current one and starting a new one. There may be other urgent work in the queue ahead of you that can't wait for a release candidate to be refreshed or it's undesirable to have other changes included.
+
+### Production Releases
+
+Production releases should only be done Monday through Thursday, 8am-4pm EST.  This mitigates the risk of regressions or unanticipated production bugs from occurring during off-hours.
+
+Exceptions to this rule are up to the team's discretion, but some general cases where this might be done:
+
+- Production is completely down
+- Bug in the critical path of the application
+- Delivery of certain functionality is urgent (typically this is due to deadline timing of other teams)

--- a/docs/handbook/delivering/release-process/webapp-release-process.md
+++ b/docs/handbook/delivering/release-process/webapp-release-process.md
@@ -1,0 +1,87 @@
+# Web Application Release Process
+
+## Responsibilities
+
+### Individual Engineer
+
+As an engineer you have responsibilities to ensure the work you've done is reliably released into production:
+
+
+- Before your code is merged:
+  - Coordinate with DevOps on having configuration in place both on RC and production for your changes _before_ it gets merged so that releases are not held up.
+- After your code is merged:
+  - When the changes have been deployed on RC, verify your changes via functional testing and obtain acceptance from any necessary stakeholders.
+- After your code is released:
+  - Perform smoke testing of the functionality if it won't interfere with other application users.
+
+### Engineering Team
+
+Collectively, the team members who have made changes are responsible for coordinating the release to production:
+
+- The team members who have changes to the main branch are responsible for verifying their changes:
+  - The release candidate PR will contain a checklist of the included changes by commit message.
+  - Each engineer should:
+    - Perform a functional test of their changes.  
+    - If testing is successful, the engineer should check the box next to the associated PR in the release-candidate PR.
+    - Any bug or regression discovered during testing should be communicated.
+- When all changes in the release candidate have been verified by the team (all checkboxes have been checked), the engineer who has been designated Release Manager releases it to production.
+  - The Release Manager should monitor the release and application logs to ensure no errors are occurring.
+  - If the release failed, the Release Manager should investigate, communicating with other team members who are more informed about the problem area.
+
+## Release Lifecycle
+
+```mermaid
+sequenceDiagram
+  actor eng as Software Engineers
+  participant branchmain as main/master <br> branch
+  participant envci as CI <br> Environment
+
+  participant branchrc as release-candidate <br> branch
+  participant envrc as Release Candidate <br> Environment
+
+  participant branchrelease as release <br> branch
+  participant envprod as Production <br> Environment
+
+  loop
+    eng->>branchmain: Merge pull requests
+  end
+
+  critical Automated CI Deployments
+    branchmain->>envci: Deploy to CI
+  end
+
+  Note over eng: Requests a release candidate
+
+  critical New Release Candidate
+    branchmain->>branchrc: Latest code merged
+    branchrc->>branchrc: Release notes and PR generated
+    branchrc->>envrc: Deploy to RC
+    eng->>envrc: Engineer verifies their commit(s)
+    note over eng: Checks off boxes on the PR
+  end
+
+  critical Production Release
+    eng->>branchrc: Engineer coordinated release approval
+    branchrc->>branchmain: Merged back to main
+    branchmain->>branchrelease: Main branch merged to release
+    branchrelease->>envprod: Deploy to Production
+  end
+```
+
+
+## Versioning
+
+Our releases are versioned using a date-based versioning scheme following the pattern `YYYY.MM.DD.#`:
+
+- `YYYY` - full year
+- `MM` - zero-padded month number
+- `DD` - zero-padded day of the month
+- `#` - release number starting at `0` for the first release that day and incrementing on each subsequent release
+
+For example: 
+
+- `2022.03.15.0` would be the first release on March 15, 2022.
+- `2022.03.15.7` would be the seventh release on March 15, 2022.
+- `2022.03.16.0` would be the first release on March 16, 2022 (release number resets the next day).
+
+

--- a/docs/handbook/deprecated-docs/MITx-edx-integration-devstack.md
+++ b/docs/handbook/deprecated-docs/MITx-edx-integration-devstack.md
@@ -1,0 +1,193 @@
+# Integrating MIT Applications with Open edX using Devstack
+
+| Application | PORT | Domain               |
+|-------------|------|----------------------|
+| MITxPro     | 8053 | xpro.odl.local       |
+| MITxOnline  | 8013 | mitxonline.odl.local |
+
+In order to create user accounts in Open edX and enable authentication from MIT Application to Open edX, you need to configure MIT Application as an OAuth2 provider for Open edX.
+
+## Setup Open edX Devstack
+
+Following steps are inspired by [edx-devstack](https://github.com/edx/devstack).
+
+## Add `/etc/hosts` alias for Open edX
+
+If one doesn't already exist, add an alias to `/etc/hosts` for Open edX. We have standardized this alias
+to `edx.odl.local`. Your `/etc/hosts` entry should look like this::
+
+`127.0.0.1  edx.odl.local`
+
+## Clone edx/devstack
+
+    git clone https://github.com/edx/devstack
+    cd devstack
+    make requirements
+    make dev.clone
+
+## Pull latest images and run provision
+
+    make pull
+    make dev.provision
+
+## Start your servers
+
+    make dev.up
+
+## Stop your servers
+
+    make stop
+
+## Setup social auth
+
+### Install `ol-social-auth` in LMS
+
+There are two options for this:
+
+#### Install via pip
+
+    pip install ol-social-auth
+
+#### Install from local Build
+
+- Checkout the [ol-social-auth](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_social_auth) project and build the package per the project instructions
+- Copy the `ol-social-auth-$VERSION.tar.gz` file into devstack's `edx-platform` directory
+- In devstack, run `make lms-shell` and within that shell `pip install ol-social-auth-$VERSION.tar.gz`
+
+    - To update to a new development version without having to actually bump the package version, simply `pip uninstall ol-social-auth`, then install again
+
+### Install `openedx-companion-auth` in LMS
+
+There are two options for this:
+
+#### Install via pip
+
+    pip install openedx-companion-auth
+
+#### Install from local Build
+
+- Checkout the [openedx-companion-auth](https://github.com/mitodl/open-edx-plugins/tree/main/src/openedx_companion_auth) project and build the package per the project instructions
+- Copy the `openedx-companion-auth-$VERSION.tar.gz` file from the `dist` folder into devstack's `edx-platform` directory
+- In devstack, run `make lms-shell` and within that shell `pip install openedx-companion-auth-$VERSION.tar.gz`
+
+  - To update to a new development version without having to actually bump the package version, simply `pip uninstall -y openedx-companion-auth`, then install again
+---------------------------------------------------------------------------------------------------------------------------------------------------
+## Configure Open edX user and token for use with Application management commands
+
+- In Open edX, create a staff user `mit_application_serviceworker` and then under `/admin/oauth2_provider/accesstoken/` add access token with that newly created staff user.
+
+## MIT Application Setup
+
+To set up MIT Application:
+
+1. Get the gateway IP for the `EDX_APP`
+   1. Linux users: You can use `docker network inspect <LMS_COTNAINER_NAME> | grep Gateway`
+   2. OSX users: Use `host.docker.internal`
+
+2. Set up your `.env` file. These settings need particular attention:
+
+   - `OPENEDX_IP`: set to the gateway IP from the first step.
+   - `OPENEDX_API_BASE_URL`: set to `http://<EDX_HOSTNAME>:<PORT>`
+   - `OPENEDX_SERVICE_WORKER_USERNAME`: set to `mit_Application_serviceworker` (unless you changed this)
+   - `OPENEDX_SERVICE_WORKER_API_TOKEN`: set to the token you just generated
+   - `OPENEDX_OAUTH_PROVIDER`: set to `ol-oauth2`
+   - `OPENEDX_SOCIAL_LOGIN_PATH`: set to `/auth/login/ol-oauth2/?auth_entry=login`
+
+   - Build the MIT Application: `docker-compose build`
+
+## Run the `configure_instance` management command
+
+    docker-compose run --rm web ./manage.py configure_instance linux --gateway <ip>
+
+  Where `<ip>` is the IP from the first step. (On macOS, specify macos instead of linux. You can also skip --gateway.) You will need to supply passwords for the MIT Application superuser and test learner accounts. **Make a note of the client ID and secret that it will print out at the end.**
+
+## Configure MIT application as a OAuth provider for Open edX
+
+In Open edX (derived from instructions [`here`](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/tpa/tpa_integrate_open/tpa_oauth.html#additional-oauth2-providers-advanced)):
+
+- Create `private.py` file at `edx-platform/lms/envs/{here}` and add the following configurations to allow additional OAuth providers
+
+  ```
+  from .production import AUTHENTICATION_BACKENDS, FEATURES, IDA_LOGOUT_URI_LIST, REGISTRATION_EXTRA_FIELDS
+
+  FEATURES["ALLOW_PUBLIC_ACCOUNT_CREATION"] = True
+  FEATURES["ENABLE_COMBINED_LOGIN_REGISTRATION"] = True
+  FEATURES["ENABLE_THIRD_PARTY_AUTH"] = True
+  FEATURES["ENABLE_OAUTH2_PROVIDER"] = True
+  FEATURES["SKIP_EMAIL_VALIDATION"] = True
+
+  REGISTRATION_EXTRA_FIELDS["country"] = "hidden"
+
+  THIRD_PARTY_AUTH_BACKENDS = ["ol_social_auth.backends.OLOAuth2",]
+
+  AUTHENTICATION_BACKENDS = list(THIRD_PARTY_AUTH_BACKENDS) + list(AUTHENTICATION_BACKENDS)
+
+  IDA_LOGOUT_URI_LIST = list(IDA_LOGOUT_URI_LIST) + list(["http://{Domain}:{PORT}/logout"])
+
+  SOCIAL_AUTH_OAUTH_SECRETS = {
+    "ol-oauth2": <mit_app_client_secret>  // you just copied from configure_instance command output
+  }
+  ```
+
+- Login to django-admin (default username and password can be found [`here`](https://github.com/openedx/devstack#usernames-and-passwords)), go to `http://edx.odl.local:18000/admin/third_party_auth/oauth2providerconfig/`, and create a new config:
+
+  - Select the default example site
+  - The slug field **MUST** match the the backend's name, which for us is `ol-oauth2`
+  - Check the following checkboxes:
+
+    - Enabled
+    - Skip hinted login dialog
+    - Skip registration form
+    - Sync learner profile data
+    - Enable SSO id verification
+  - Set Backend name to: `ol-oauth2`
+
+  - In "Other settings", put:
+
+    ```
+    {
+        "AUTHORIZATION_URL": "http://{Domain}:{PORT}/oauth2/authorize/",
+        "ACCESS_TOKEN_URL": "http://<EXTERNAL_MIT_APP_HOST>:<PORT>/oauth2/token/",
+        "API_ROOT": "http://<EXTERNAL_MIT_APP_HOST>:<PORT>/"
+    }
+    ```
+
+  - `EXTERNAL_MIT_APP_HOST` will depend on your OS, but it needs to be resolvable within the edx container
+
+    - Linux users: The gateway IP of the docker-compose networking setup for MIT Application as found via `docker network inspect mit-Application_default | grep Gateway` e.g; `docker network inspect mitxonline_default | grep Gateway`
+    - OSX users: Use `host.docker.internal`
+
+  - Save the configuration.
+
+## Configure Open edX to support OAuth2 authentication from MITx Application
+
+   - Go to `http://edx.odl.local:18000/admin/oauth2_provider/application/` and add/edit the `edx-oauth-app` entry.
+   - Ensure these settings are set:
+
+      - Name: `edx-oauth-app`
+      - Redirect uris: `http://{Domain}:{PORT}/login/_private/complete`
+      - Client type: `Confidential`
+      - Authorization grant type: `Authorization code`
+      - Skip authorization is checked.
+
+   - Save `Client id` and `Client secret`.
+
+Update your MIT Application `.env` file. Set `OPENEDX_API_CLIENT_ID` and `OPENEDX_API_CLIENT_SECRET` to the values from the record you created or updated in the last step.
+
+Also set the **LOGOUT_REDIRECT_URL** in `.env`:
+
+    LOGOUT_REDIRECT_URL=http://edx.odl.local:18000/logout
+
+  - Build the MIT Application: `docker-compose build`
+
+You should now be able to run some MIT Application management commands to ensure the service worker is set up properly:
+
+   - `sync_courserun --all ALL` should sync the two test courses (if you made them).
+      - `sync_courseruns --all ALL` in MITxPro
+   - `repair_missing_courseware_records` should also work.
+
+In the separate browser session, attempt to log in again. This time, you should be able to log in through MIT Application, and you should be able to get to the edX LMS dashboard. If not, then double-check your provider configuration settings and try again.
+
+   - If you are still getting "Can't fetch settings" errors, **make sure** your Site is set properly - there are three options by default and only one works. (This was typically the problem I had.)
+
+**Optionally**, log into the LMS Django Admin and make your MIT Application superuser account a superuser there too.

--- a/docs/handbook/how-to/caching.md
+++ b/docs/handbook/how-to/caching.md
@@ -1,0 +1,88 @@
+# Caching
+
+### When to consider caching
+
+- Frequently requested data
+- Expensive data computations
+- Upstream resource contention (e.g. high server load)
+- Slow client-facing responses
+- Assets (e.g. css, js, images)
+
+### How to cache
+
+Caching isn't a one-size-fits-all problem. Consideration needs to be made for the nature of the data being cached to determine the best way in which to cache. Some questions to ask about the nature of the data:
+
+- What is the lifecycle of this data?
+  - How often does it change?
+  - Do we know when it changes?
+    - Can we automate cache purge/eviction?
+    - Will need to force a cache purge/eviction?
+- How tolerant is the application or user experience to stale data?
+  - What problems could caching this data cause (race conditions, decisions made on stale data)?
+  - Can it be cached indefinitely?
+  - Can it be cached for a shorter interval (hours, minutes, seconds)?
+  - Can it be cached for the duration of the request?
+
+### Types of caching
+
+These types could in theory be layered, but such an approach should be taken with caution as it becomes more difficult to reason about a system with multiple caching layers, particularly when we don't control one or more of those layers, such as a CDN.
+
+#### Application level caching
+
+Application level caching should be considered for data that is resource intensive to compute or is requested very frequently. It also typically requires that this data isn't user-dependent. It can be done at any level within the application (view, database query, etc). These values would typically be cached in the configured django cache (typically Redis for us). Because we control the cache storage and retrieval, we can invalidate it ourselves as well.
+
+Data can be cached for hours, minutes, seconds, or even just for the duration of the request. Which is best is highly dependent on the nature of the data and testing and experimentation with values is always a good idea.
+
+Some examples:
+
+- A list of courses available
+- Pricing information
+-
+
+**Use application level caching for data that is mutable over time and is expensive to compute.**
+
+#### Request level caching
+
+Request level caching instructs the browser and CDNs on how to cache content at the request level, this typically involves a number of HTTP request and response headers working in concert.
+
+- For all content:
+  - `ETag`/`Last-Modified` headers on responses and handle `If-None-Match`/`If-Modified-Since` on incoming requests
+- Content that never changes
+  - _e.g._ css, js, image assets served with a hashed filename
+  - Requires a unique url for this content
+  - Use `Cache-Control` with a long `max-age` - CDNs and browsers will cache for a long time
+- Content that changes, but not that often:
+  - _e.g._ a marketing page
+  - Use `Cache-Control: no-cache` (the response will still be cached, but the downstream CDN will check the upstream server first before serving the cached version)
+- Content that should be cached by the browser, but not the CDN:
+  - _e.g._ a profile page
+  - Use `Cache-Control: private`
+  - Very likely a short-lived `max-age` (i.e. 30s)
+
+### Cache Purging
+
+Caches may occasionally need purging, it's important to know ahead of time how this is done.
+
+- CDNs often have an option to purge the entire cache, this is typically something our DevOps team can perform
+- Application level caching can be purged by evicting individual values
+  - **NOTE:** currently both celery and the django cache use the same redis instance, so it's not possible to purge everything at the cache level
+
+
+**Use request level caching for content that never or infrequently changes. Support the appropriate headers for the latter.**
+
+### Specifics
+
+#### Wagtail
+
+We use Wagtail in many of our products, some best practices on caching performantly:
+
+- Using the dynamic image serve view ([Example in xPro](https://docs.wagtail.io/en/stable/advanced_topics/images/image_serve_view.html))
+- Adding a header to cache the dynamically-served images in a user's browser ([Example in xPro](https://github.com/mitodl/mitxpro/blob/abef74ad530770cc8772620dedae20714fc1a2e5/mitxpro/urls.py#L95-L105))
+- Caching image renditions in Redis ([Example in xPro](https://docs.wagtail.io/en/v2.9.3/advanced_topics/performance.html#caching-image-renditions) - requires Wagtail 2.9+)
+- Using a custom templatetag which adds a version to each rendered image, allowing us to cache at the CDN level ([Example in xPro](https://github.com/mitodl/mitxpro/blob/e8e5002662f794c3b17a63063af0d1aad293bff3/cms/templatetags/image_version_url.py#L12))
+
+
+### Resources
+
+- [Mozilla HTTP Caching Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching)
+- [Caching Best Practices](https://jakearchibald.com/2016/caching-best-practices/)

--- a/docs/handbook/how-to/common-web-app-guide.md
+++ b/docs/handbook/how-to/common-web-app-guide.md
@@ -1,0 +1,314 @@
+# Web App Guide
+
+# Docker/Django/Webpack Web App Guide
+
+**SECTIONS**
+1. [Initial Setup](#initial-setup)
+1. [Running and Accessing the App](#running-and-accessing-the-app)
+1. [Testing and Formatting](#testing-and-formatting)
+1. [Administering your Local App](#administering-your-local-app)
+1. [Troubleshooting](#troubleshooting)
+
+
+# Initial Setup
+
+### Major Dependencies
+- Docker
+  - _[OSX only]_ We use **Docker for Mac**&#42;, a desktop development environment that includes Docker.  
+    Recommended OSX install method: [Download from Docker website](https://store.docker.com/editions/community/docker-ce-desktop-mac)
+- docker-compose
+  - Recommended install: pip (`pip install docker-compose`)
+
+_&#42; For OSX development, we previously used docker-machine, which is used to run Docker containers
+inside of a VM. Since that time, Docker for Mac has improved to the point that Docker can be run from
+the host machine._
+
+### Build And Configure Docker Containers
+
+All commands in this guide should be run from the root directory of your project's repository (unless specified otherwise).
+
+#### 1) Create your ``.env`` file
+
+    cp .env.example .env
+
+The `.env.example` file contains settings variables for which you will need to provide values in order to run the
+app. Sometimes default values are given. To get a better idea about what values are needed, refer to the specific
+project's README file.
+
+#### 2) Build the containers
+
+    docker-compose build
+
+*NOTE: You will also need to run this command whenever requirements files change (``requirements.txt``, ``test_requirements.txt``, etc.)*
+
+#### 3) Create database tables from the Django models
+
+    docker-compose run web ./manage.py migrate
+
+*NOTE: You will also need to run this command whenever there are new migrations (i.e.: database models have been changed/added/removed).*
+
+#### _(Optional)_ Create a superuser
+Some of our apps include user creation as part of their specific setup steps. If the given app does not
+include steps to create a user, you can create one easily via Django's `createsuperuser` command.
+It will prompt you for the username and some other details for this user.
+
+    docker-compose run web ./manage.py createsuperuser
+
+### Add `/etc/hosts` alias for the site
+
+There are two scenarios where this will be needed:
+
+1. Multiple locally-running apps need to share a cookie (e.g.: MicroMasters and Open Discussions).
+1. You are an OSX user. Due to networking differences between Docker for Mac and standard Docker, locally running apps can only communicate
+with each other in OSX if `/etc/hosts` aliases are created for each app.
+
+Our established pattern is to use `odl.local` as the domain. The `/etc/hosts` entry for a locally-running site will look like this:
+
+```
+127.0.0.1       <site_abbreviation>.odl.local
+
+# Example: for Micromasters...
+127.0.0.1       mm.odl.local
+# Example: for open-discussions...
+127.0.0.1       od.odl.local
+```
+
+# Running and Accessing the App
+
+#### 1) Run the containers
+
+Start all the services that are required to run the app:
+
+    docker-compose up
+
+#### 2) Navigate to the running app in your browser
+
+Your app should now be accessible via browser:
+
+1. The URL of the locally-running site needs to include the port number that the `nginx` service is running on.
+    - One-line command to figure out that port number: `docker-compose ps nginx | perl -nle '/[0-9\.]*:(\d+)/ && print "$1";'`
+    - This port number is specified for the `nginx` service in `docker-compose.yml`
+1. _[Linux only]:_ Navigate to `localhost:PORT` (e.g.: `localhost:8079`)
+1. _[OSX only]:_ Navigate to `ETC_HOSTS_ALIAS:PORT` (e.g.: `mm.odl.local:8079`). Like Linux users, you _can_ navigate to `localhost:PORT` (e.g.: `localhost:8079`) to use the
+  locally-running site, but it's recommended/essential that you add an `/etc/hosts` alias and use that URL instead.
+  More info on that in the section above.
+
+
+# Testing and Formatting
+
+There are a few different commands for running tests/linters and formatting code.
+
+*NOTE: The `--rm` option for the `docker-compose run` command tells Docker to destroy the container after it finishes running. This is useful for running specific commands in one-off containers. This prevents the accumulation of unused Docker containers on your machine.*
+
+### Python tests, linting, and formatting
+
+We use `pytest` (with various plugins) to run our Python test suite in most of our projects. In some of legacy projects, we use `tox` to invoke `pytest`. You'll run `pytest` if there is no `tox` requirement in `test_requirements.txt` for your project.
+
+#### With `pytest`...
+```bash
+# Run Python tests with linting
+docker-compose run --rm web pytest
+# Run Python tests in a single file
+docker-compose run --rm web pytest /path/to/test.py
+# Run Python test cases in a single file that match some function/class name
+docker-compose run --rm web pytest /path/to/test.py -k test_some_logic
+# Run Python tests without linter, without coverage report, and without log capture
+docker-compose run --rm web pytest --no-cov --no-pylint --show-capture=no
+# Some of our projects allow you to pass in a single flag to run tests only (no linter, cov report, or log capture)
+docker-compose run --rm web pytest --simple
+
+### Linting
+# If the pytest-pylint is NOT installed (check test_requirements.txt), run pylint directly
+docker-compose run --rm web bash -c "pylint ./**/*.py"
+# If the pytest-pylint IS installed, run the pylint via pytest
+docker-compose run --rm web pytest --pylint -m pylint
+```
+
+#### With `tox`...
+```bash
+# Run Python tests
+docker-compose run --rm web tox
+# Run Python tests in a single file
+docker-compose run --rm web tox /path/to/test.py
+# Run Python test cases in a single file that match some function/class name
+docker-compose run --rm web tox /path/to/test.py -- -k test_some_logic
+# Run Python linter
+docker-compose run --rm web pylint
+```
+
+#### Formatting
+Most of our projects use the `black` formatter to enforce certain formatting rules. This should be run before any commit that makes changes to Python code (ignore this if your project does not list `black` in the `test_requirements.txt`).
+```bash
+# Format all Python files in the repo
+docker-compose run --rm web black .
+# Format a specific file
+docker-compose run --rm web black /path/to/file.py
+```
+
+#### Import sorting
+Some of our projects include [`isort`](https://pypi.org/project/isort/) to automatically sort Python imports. If your project uses `isort` and requires sorted imports as a part of the build, that package will be included in `test_requirements.txt`
+
+```
+# Sort all imports 
+docker-compose run --rm web bash -c "isort ."
+# Check to see if imports are sorted
+docker-compose run --rm web bash -c "isort -c ."
+```
+
+#### Speeding up test development
+There are many scenarios where you'll want to run tests many times in a row (authoring new tests, fixing old tests and checking if they pass). In that case it will save time to run a bash shell in a new container and run these commands as needed in that container.
+
+```bash
+# On host machine...
+docker-compose run --rm web bash
+# On the bash prompt inside the new container
+# Without tox...
+pytest /path/to/test.py
+# With tox...
+tox /path/to/test.py
+```
+
+### JS/CSS tests, linting, formatting, and type-checking
+
+#### Running tests via helper script
+
+Most of our projects include a helper script to run JS tests. 
+
+If your project includes `/scripts/test/js_test.sh` or `/js_test.sh`, this is how you can run the JS test suite:
+
+```bash
+docker-compose run --rm watch ./scripts/test/js_test.sh
+# Run JS tests in specific file
+docker-compose run --rm watch ./scripts/test/js_test.sh path/to/file.js
+# Run JS tests in specific file with a description that matches some text
+docker-compose run --rm watch ./scripts/test/js_test.sh path/to/file.js "should test basic arithmetic"
+```
+
+**NOTE:** 
+In some of our projects we include a shell script that runs the entire test suite including linting, etc.: `./test_suite.sh`.
+If you're in yarn workspaces enabled project e.g. MITxOnline, you will need to replace `yarn run` with `yarn workspaces foreach run` for the below commands.
+
+
+#### Running tests via yarn
+
+In 2021 we changed our JS testing practice to use yarn directly to run the JS test suite, and to use [jest](https://jestjs.io/docs/getting-started) 
+as our testing framework.
+
+If your project DOES NOT include a `js_test.sh` file, this is how you can run the JS test suite:
+
+```bash
+docker-compose run --rm watch yarn run test
+# Run JS tests in specific file
+docker-compose run --rm watch yarn run test path/to/file.test.js
+# Run JS tests in specific file with a description that matches some text
+docker-compose run --rm watch yarn run test path/to/file.test.js -- -t "should test basic arithmetic"
+
+# Run jest in watch mode (`jest --watch`) to continuously catch test failures
+docker-compose run --rm watch yarn run test:watch
+# Generate a coverage report
+docker-compose run --rm watch yarn run test:coverage
+```
+
+#### Linting and formatting
+
+```bash
+# Run the JS linter
+docker-compose run --rm watch yarn run lint
+# Run SCSS linter
+docker-compose run --rm watch yarn run scss_lint
+# Run prettier-eslint, which fixes style issues that may be causing the build to fail
+docker-compose run --rm watch yarn run fmt
+```
+
+#### Type-checking
+
+Most of our legacy projects use [Flow](https://flow.org/en/docs/) 
+type-checking. We switched to Typescript for new projects in 2021. Type-checking only needs to be invoked directly 
+in our projects that use Flow. If your project has files with the extension `.ts`/`.tsx`, your project is 
+Typescript-enabled.
+
+**Typescript** 
+
+As stated above, type-checking is done automatically with Typescript-enabled projects, so it's not necessary to run
+any commands, but you can still type-check with a command if you prefer:
+
+```bash
+docker-compose run --rm watch yarn run typecheck
+```
+
+This runs `tsc --noEmit`, which basically type-checks the program and outputs
+any error but does not run a full compilation. We have incremental compilation
+turned on, so this should be relatively fast. It uses a file called
+`.tsbuildinfo` for incremental compilation.
+
+**Flow**
+
+```bash
+# Run the Flow type checker to check for typing errors
+docker-compose run --rm watch yarn run-script flow
+```
+
+#### Speeding up test development
+You can speed up JS test development in the same way described in the Python testing section above by starting the
+`watch` container instead of the `web` container.
+
+
+# Administering your Local App
+
+#### Running a Django shell
+
+    docker-compose run --rm web ./manage.py shell
+
+#### Running the app in a notebook
+
+Some of our repos include a config for running a [Jupyter notebook](https://jupyter.org/) in a
+Docker container. This enables you to do in a Jupyter notebook anything you might otherwise do
+in a Django shell, with the added benefit of saving code that you frequently run, and running entire
+blocks of code at once. **If the repo includes a `.ipynb.example` file, that means the app is configured
+to run in a Notebook.** To get started:
+
+- Copy the example file
+    ```bash
+    # Choose any name for the resulting .ipynb file
+    cp localdev/app.ipynb.example localdev/app.ipynb
+    ```
+- Build the `notebook` container _(for first time use, or when requirements change)_
+    ```bash
+    docker-compose -f docker-compose-notebook.yml build
+    ```
+- Run all the standard containers (`docker-compose up`)
+- In another terminal window, run the `notebook` container
+    ```bash
+    docker-compose -f docker-compose-notebook.yml run --rm --service-ports notebook
+    ```
+- Visit the running notebook server in your browser. The `notebook` container log output will
+  indicate the URL and `token` param with some output that looks like this:
+    ```
+    notebook_1  |     To access the notebook, open this file in a browser:
+    notebook_1  |         file:///home/mitodl/.local/share/jupyter/runtime/nbserver-8-open.html
+    notebook_1  |     Or copy and paste one of these URLs:
+    notebook_1  |         http://(2c19429d04d0 or 127.0.0.1):8080/?token=2566e5cbcd723e47bdb1b058398d6bb9fbf7a31397e752ea
+    ```
+  Here is a one-line command that will produce a browser-ready URL from that output. Run this in a separate terminal:
+    ```bash
+    # Replace "myapp.odl.local" with the etc/hosts alias for your app (e.g.: "xpro.odl.local")
+    APP_HOST="myapp.odl.local"; docker logs $(docker ps --format '{{.Names}}' | grep "_notebook_run_") | grep -E "http://(.*):8080[^ ]+\w" | tail -1 | sed -e 's/^[[:space:]]*//' | sed -e "s/(.*)/$APP_HOST/"
+    ```
+  OSX users can pipe that output to `xargs open` to open a browser window directly with the URL from that command.
+- Navigate to the `.ipynb` file that you created and click it to run the notebook
+- Execute the first block to confirm it's working properly (click inside the block
+  and press Shift+Enter)
+
+From there, you should be able to run code snippets with a live Django app just like you
+would in a Django shell.
+
+
+# Troubleshooting
+
+#### Error message indicating that the `auth_user` table doesn't exist
+
+Try running `docker-compose run web ./manage.py migrate auth`, then run `docker-compose run web ./manage.py migrate`.
+
+#### _[OSX only]_ Error indicating that Docker for Mac is not running (even though it is running)
+
+Open a new terminal tab/window, navigate to the same directory, and re-run the same command (e.g.: `docker-compose up`). For whatever reason, a terminal window can sometimes fail to recognize that Docker for Mac is running, and a fresh terminal window will fix that.

--- a/docs/handbook/how-to/index.md
+++ b/docs/handbook/how-to/index.md
@@ -1,0 +1,6 @@
+# How-To Guides
+
+- [Caching](caching.md)
+- [Common Web App Guide](common-web-app-guide.md)
+- [New Projects](new-projects.md)
+- [Touchstone](touchstone.md)

--- a/docs/handbook/how-to/new-projects.md
+++ b/docs/handbook/how-to/new-projects.md
@@ -1,0 +1,27 @@
+# New Projects
+
+When starting a new project, we have a baseline of what's necessary
+from an infrastructure perspective. Here's a checklist:
+
+- [ ] Do you have a README?
+- [ ] Can you run the tests for your code? Is that documented in the README?
+- [ ] Do you have docker setup for local development?
+- [ ] Do you have a LICENSE file?
+- [ ] Are the tests running on a CI server like Travis?
+- [ ] Do you have relevant linters setup for the languages you're using?
+
+
+READMEs for your project.
+
+- [ ] Does it include how to install the app?
+- [ ] Does it include how to run the tests?
+- [ ] Does it contain a build status or code coverage badge?
+- [ ] Does it link to relevant documents?
+- [ ] Does it mention the software license used?
+
+
+For Django projects specifically..
+
+- [ ] Does it use the same database backend locally as it will in production?
+- [ ] Does it support both python 2.7 and either python 3.4 or 3.5 (pick one)?
+- [ ] Does it run pylint & pep8 as linters?

--- a/docs/handbook/how-to/touchstone.md
+++ b/docs/handbook/how-to/touchstone.md
@@ -1,0 +1,128 @@
+# Touchstone Integration
+
+### Pre-requisites
+- Python packages
+  - python-social-auth
+  - social-auth-app-django
+  - python3-saml
+  
+- OS requirements
+  - libxmlsec1-dev
+    - This should be added to `apt.txt` and `Aptfile`.
+    - `https://github.com/heroku/heroku-buildpack-apt` should be 1st in the `buildpacks` section of `app.json`
+    
+- X509 certificate and private key
+  ```shell
+   openssl req -new -x509 -days 3650 -nodes -out saml.crt -keyout saml.key
+   ```
+   
+- Touchstone identity provider (idp) metadata information
+  - https://idp.mit.edu/idp/shibboleth
+  
+### Django metadata view and URL
+Create a public (no authentication) Django view to display SAML metadata in your app. For example:
+
+  ```python
+    from social_django.utils import load_strategy, load_backend
+  
+    def saml_metadata(request):
+        """ Display SAML configuration metadata as XML """
+        saml_backend = load_backend(
+            load_strategy(request),
+            "saml",
+            redirect_uri=reverse('social:complete', args=("saml", )),
+        )
+        metadata, _ = saml_backend.generate_metadata_xml()
+        return HttpResponse(content=metadata, content_type='text/xml')
+  ```
+  
+Create a url for the view:
+
+   ```python
+    url(r'^saml/metadata/', saml_metadata, name='saml-metadata'),
+   ```  
+
+### Metadata configuration
+Using settings and environment variables, populate the required info for the SAML metadata:
+
+```python
+SOCIAL_AUTH_SAML_SP_ENTITY_ID = '<Use the full metadata URL, ie https://myserver.edu/saml/metadata>'
+SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = '<x509 certificate with all line breaks removed>'
+SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = '<x509 key with all line breaks removed>'
+
+SOCIAL_AUTH_SAML_ORG_INFO = {
+    "en-US": {
+        "name": urlparse(SITE_BASE_URL).netloc,
+        "displayname": "<Enter any approproate value>",
+        "url": SITE_BASE_URL
+    }
+}
+SOCIAL_AUTH_SAML_TECHNICAL_CONTACT = {
+    "givenName": "<Technical contact name>",
+    "emailAddress": "<Technical contact email>"
+}
+SOCIAL_AUTH_SAML_SUPPORT_CONTACT = SOCIAL_AUTH_SAML_TECHNICAL_CONTACT
+SOCIAL_AUTH_SAML_ENABLED_IDPS = {
+    "default": {
+        "entity_id": "https://idp.mit.edu/shibboleth",
+        "url": "https://idp.mit.edu/idp/profile/SAML2/Redirect/SSO",
+        "attr_user_permanent_id": "urn:oid:1.3.6.1.4.1.5923.1.1.1.6", #EPPN
+        "attr_username": "urn:oid:2.16.840.1.113730.3.1.241", #NAME
+        "attr_email": "urn:oid:0.9.2342.19200300.100.1.3", #EMAIL
+        "x509cert": "<ds:X509Certificate value without linebreaks from Touchstone idp metadata>",
+    }
+}
+
+SOCIAL_AUTH_SAML_SECURITY_CONFIG = {
+    "wantAssertionsEncrypted": True, # Mandatory for Touchstone
+    "requestedAuthnContext": False  # If false, enables web certificate option in Touchstone
+}
+
+```
+
+
+### Social auth pipeline: add a profile for the user
+
+Add a step to the social-auth pipeline for creating a user profile, for example:
+
+   ```python
+    # settings.py
+    SOCIAL_AUTH_PIPELINE = (
+      .....
+      # require a profile if they're not set via SAML
+      'authentication.pipeline.user.require_profile_update_user_via_saml',
+      .....
+    )
+    
+    # authentication/pipeline/user.py
+    @partial
+    def require_profile_update_user_via_saml(
+            strategy, backend, user=None, is_new=False, *args, **kwargs
+    ):  # pylint: disable=unused-argument    
+        if backend.name != SAMLAuth.name or not is_new:
+            return {}
+
+        profile, _ = Profile.objects.update_or_create(
+            user=user,
+            defaults={
+                'name': user.get_full_name()
+            },
+        )
+
+        return {
+            'user': user,
+            'profile': profile,
+        }
+   ```
+
+### Register your app with Touchstone
+
+Contact touchstone-support@mit.edu and request to register your app.  
+
+Include the x509 certificate string along with the following:
+```
+Web server host name: URL of your SAML metadata
+Contact email address: odl-discussions-support@mit.edu
+Organization Name: MIT Office of Digital Learning
+Organization URL: https://openlearning.mit.edu  
+```

--- a/docs/handbook/index.md
+++ b/docs/handbook/index.md
@@ -1,0 +1,5 @@
+# Engineering Handbook
+
+This contains information for how MIT's Office of Open Learning (OL) does things. The breadth of this covers coding conventions to project requirements and more.
+
+To make changes, issue a pull request against [mitodl/platform-engineering-site](https://github.com/mitodl/platform-engineering-site). Discussion can happen within the pull request itself.

--- a/docs/handbook/openedx/MITx-edx-integration-tutor.md
+++ b/docs/handbook/openedx/MITx-edx-integration-tutor.md
@@ -1,0 +1,157 @@
+# Integrating MIT Applications with Open edX using Tutor
+
+| Application | Port | MIT_APP_Domain       |
+|-------------|------|----------------------|
+| MITxPro     | 8053 | xpro.odl.local       |
+| MITxOnline  | 8013 | mitxonline.odl.local |
+
+In order to create user accounts in Open edX and permit authentication from MIT Application to Open edX, you need to configure MIT Application as an OAuth2 provider for Open edX.
+
+## Prerequisite
+
+To begin, you need to follow the [Installing Tutor for development](https://docs.tutor.edly.io/dev.html#open-edx-development) instructions provided by Tutor **for local development installations**. 
+
+Once Tutor has bootstrapped itself and is available, create a superuser account:
+
+    tutor dev do createuser --staff --superuser edx edx@example.org
+
+Log in to your edX and MIT application as an admin and make sure the session remains active throughout the process. (Part of this process will involve mostly breaking authentication, so it's important that you are able to access the admin).
+
+#### For MITxOnline Only
+For best results, create two new courses within edX. The MITxOnline `configure_instance` command expects a couple of courses to exist in edX (because they come with the devstack package):
+
+| Course ID                       | Course Title         |
+|---------------------------------|----------------------|
+| course-v1:edX+DemoX+Demo_Course | Demonstration Course |
+| course-v1:edX+E2E-101+course    | E2E Test Course      |
+
+If you have a devstack instance handy, you can export these and import them into Tutor. Otherwise, just create them and make sure to set dates for the courses (they default to 2030 otherwise).
+
+## Configure Open edX to support OAuth2 authentication from MIT Application
+
+   1. Go to [`http://local.openedx.io:8000/admin/oauth2_provider/application/`](http://local.openedx.io:8000/admin/oauth2_provider/application/) and add the `{app_name}-oauth-app` entry.
+   2. Ensure these settings are set:
+
+      - Name: `{app_name}-oauth-app`  (Example: `xpro-oauth-app`)
+      - Redirect uris: `http://{MIT_APP_Domain}:{Port}/login/_private/complete` (Example: For MIT xPRO, it will be `http://xpro.odl.local:8053/login/_private/complete`)
+        For MITxOnline only, add the following URL under Redirect URIs: `http://mitxonline.odl.local:9080/_/auth/complete`
+      - Client type: `Confidential`
+      - Authorization grant type: `Authorization code`
+      - Skip authorization is checked.
+
+   3. Save `Client id` and `Client secret`.
+
+## Create an access token to use with MIT Application management commands
+
+1. Create a service worker for the MIT Application. Remember the password.
+
+       tutor dev do createuser --staff mit_Application_serviceworker service@mitx.odl.local
+
+2. In a private window, log in with the service account you created in step 1. This will generate an access token for the service user.
+3. Go to [`http://local.openedx.io:8000/admin/oauth2_provider/accesstoken/`](http://local.openedx.io:8000/admin/oauth2_provider/accesstoken/) and verify that the access token has been generated for the service worker account.
+4. Modify the `Expires` date to a date in the future and save the changes.
+
+## MIT Application Setup
+
+To set up the MIT Application:
+
+1. Get the gateway IP for the `EDX_APP`
+   - Linux users: The gateway IP of the docker-compose networking setup for edx LMS
+
+         docker network inspect tutor_dev_default | grep Gateway
+
+   - OSX users: Use `host.docker.internal`
+
+2. Set up your `.env` file. These settings need particular attention:
+
+   - `OPENEDX_IP`: set to the gateway IP from the first step.
+   - `OPENEDX_API_BASE_URL`: set to `http://<EDX_HOSTNAME>:<PORT>` (You can use `http://local.openedx.io:8000` in case you are using tutor for local development)
+   - `OPENEDX_SERVICE_WORKER_USERNAME`: set to `mit_Application_serviceworker` (unless you changed this)
+   - `OPENEDX_SERVICE_WORKER_API_TOKEN`: set to the token you just generated in the above step
+   - `OPENEDX_OAUTH_PROVIDER`: set to `ol-oauth2`
+   - `OPENEDX_SOCIAL_LOGIN_PATH`: set to `/auth/login/ol-oauth2/?auth_entry=login`
+   - `OPENEDX_API_CLIENT_ID`: set to the client id of the OAuth application you created in the above steps
+   - `OPENEDX_API_CLIENT_SECRET`: set to the client secret of the OAuth application you created in the above steps
+   - `LOGOUT_REDIRECT_URL`: set to `http://<EDX_HOSTNAME>:<PORT>/logout` (You can use `http://local.openedx.io:8000/logout` in case you are using tutor for local development)
+
+    Run the `docker-compose up -d` command after setting these values.
+
+3. Run the **configure_instance** command
+
+    For `gateway_ip`, use the Gateway IP from the first step. (Specify `macos` or `linux` based on your OS. You can also skip --gateway.) The command will print `Client ID` and `Client Secret` that you will need further in the setup, so keep them safe. Alternatively, you can access the `Client ID` and `Client Secret` through the MIT Application's `/admin/oauth2_provider/application/`
+           
+       docker-compose run --rm web ./manage.py configure_instance <linux or macos> --gateway <gateway_ip from above step> --tutor-dev
+
+## EdX Application Setup
+
+1. Linux Users: Get the gateway IP of the `mitApplication_default` Docker network. Example:
+
+       docker network inspect mitxpro_default | grep Gateway
+
+2. Install the required dependencies using one of the following:
+
+   - **Option 1:** Open the LMS container shell using `tutor dev exec -it lms bash` and run:
+     
+         pip install ol-social-auth openedx-companion-auth
+
+   - **Option 2:** Follow the [Tutor guide for installing extra requirements](https://docs.tutor.edly.io/configuration.html#installing-extra-xblocks-and-requirements).
+
+3. Create a `private.py` file under `edx-platform/lms/envs/` and add the following configurations to allow additional OAuth providers
+
+   ```
+   from .production import AUTHENTICATION_BACKENDS, FEATURES, IDA_LOGOUT_URI_LIST, REGISTRATION_EXTRA_FIELDS
+
+   FEATURES["ALLOW_PUBLIC_ACCOUNT_CREATION"] = True
+   FEATURES["SKIP_EMAIL_VALIDATION"] = True
+
+   REGISTRATION_EXTRA_FIELDS["country"] = "hidden"
+
+   THIRD_PARTY_AUTH_BACKENDS = ["ol_social_auth.backends.OLOAuth2",]
+
+   AUTHENTICATION_BACKENDS = list(THIRD_PARTY_AUTH_BACKENDS) + list(AUTHENTICATION_BACKENDS)
+
+   IDA_LOGOUT_URI_LIST = list(IDA_LOGOUT_URI_LIST) + list(["http://{MIT_APP_Domain}:{Port}/logout"]) (Example: For MIT xPRO, it will be `http://xpro.odl.local:8053/logout`)
+
+   SOCIAL_AUTH_OAUTH_SECRETS = {
+      "ol-oauth2": <mit_app_client_secret>  // you just copied from configure_instance command output
+   }
+   ```
+
+4. Go to [`http://local.openedx.io:8000/admin/third_party_auth/oauth2providerconfig/add/`](http://local.openedx.io:8000/admin/third_party_auth/oauth2providerconfig/add/) and add a provider configuration:
+
+    - Enabled is **checked**.
+    - Name: `Login with MIT App`
+    - Slug: `ol-oauth2`
+    - Site: `local.openedx.io:8000`
+    - Skip hinted login dialog is **checked**.
+    - Skip registration form is **checked**.
+    - Skip email verification is **checked**.
+    - Sync learner profile data is **checked**.
+    - Enable sso id verification is **checked**.
+    - Backend name: `ol-oauth2`
+    - `Client ID` and `Client Secret`: from the record created by `configure_instance` when you set up the MIT Application.
+    - Other settings:
+
+          {
+             "AUTHORIZATION_URL": "http://{MIT_APP_Domain}:{Port}/oauth2/authorize/", (Example: For MIT xPRO it will be `http://xpro.odl.local:8053/oauth2/authorize/`)
+             "ACCESS_TOKEN_URL": "http://<MITApplication_GATEWAY_IP>:<Port>/oauth2/token/",
+             "API_ROOT": "http://<MITApplication_GATEWAY_IP>:<Port>/"
+          }
+
+     where `MITApplication_GATEWAY_IP` is the IP from the `mitApplication_default` network from the first step. **Mac users**, use `host.docker.internal` for `MITxApplication_GATEWAY_IP`.
+
+You should now be able to run some MIT Application management commands to ensure the service worker is set up properly:
+
+   - `sync_courserun --all ALL` should sync the two test courses (if you made them).
+      - `sync_courseruns --all ALL` in MITxPro
+   - `repair_missing_courseware_records` should also work.
+
+In a separate browser session, attempt to log in again. This time, you should be able to log in through the MIT Application, and you should be able to get to the edX LMS dashboard. If not, then double-check your provider configuration settings and try again.
+
+   - If you are still getting "Can't fetch settings" errors, **make sure** your Site is set properly.
+
+**Optionally**, log into the LMS Django Admin and make your MIT Application superuser account a superuser there too.
+
+## Troubleshooting
+
+**Restarting** If you want to rebuild from scratch, make sure you `docker image prune`. It's also recommended to remove the Tutor project root folder - `tutor config printroot` will tell you where that is.

--- a/docs/handbook/openedx/configuring_theme_in_edX.md
+++ b/docs/handbook/openedx/configuring_theme_in_edX.md
@@ -1,0 +1,57 @@
+# Configuring themes in edX
+
+For each of our applications, we have a theme that overrides the branding in our legacy edX pages:
+- MITx Online theme: https://github.com/mitodl/mitxonline-theme
+- MITx Pro theme: https://github.com/mitodl/mitxpro-theme
+- Residential theme: https://github.com/mitodl/mitx-theme
+
+1. In edx-platform, add the following in your `private.py` file:
+   ```python
+   MARKETING_SITE_BASE_URL = <Your local marketing site url, for example, for MITxPRO we have http://xpro.odl.local:8053>
+
+   # For MITx Online only
+   UAI_COURSE_KEY_FORMATS = ["course-v1:uai_", "course-v1:mit_et"]
+   MIT_LEARN_BASE_URL = "https://learn.mit.edu"
+   MIT_BASE_URL = "https://mit.edu"
+   ```
+2. **Navigate to the Tutor Project Root Directory**
+
+   Run the following command to go to the Tutor root path:
+   ```
+   cd "$(tutor config printroot)"
+   ```
+
+3. **Clone the Theme Repository**
+
+   Go to the following directory inside the Tutor root:
+   ```
+   cd env/build/openedx/themes/
+   ```
+   Then clone the theme repo inside this folder. 
+   ```
+   git clone <theme-repo-url for e.g, https://github.com/mitodl/mitxonline-theme>
+   ```
+
+4. **Apply the Theme**
+
+   Run this command to apply your custom theme:
+   ```
+   tutor dev do settheme <theme-name for e.g, mitxonline-theme>
+   ```
+
+   Restart the LMS/CMS container.
+
+
+5. **Run the theme watcher**
+
+   Watch the themes folders for changes:
+   ```
+   tutor dev run watchthemes
+   ```
+
+## Other Settings (Not required for local setup)
+
+The configuration above is enough to run the themes locally. Below are some of the settings required for deployments:
+
+- `ENABLE_COMPREHENSIVE_THEMING`: When enabled, this toggle activates the use of the custom theme.
+- `COMPREHENSIVE_THEME_DIRS`: A list of paths to directories, each of which will be searched for comprehensive themes.

--- a/docs/handbook/openedx/edx-api-client-release-process.md
+++ b/docs/handbook/openedx/edx-api-client-release-process.md
@@ -1,0 +1,19 @@
+# edx-api-client Release Process
+
+This document describes the process for publishing a new release of the `edx-api-client` package to PyPI.
+
+## Steps to Publish a New Release
+
+1. **Go to Slack**
+   - Open the `doof-edx-api-client` Slack channel.
+   - Cut a new release using `@doof release notes` and then selecting the appropriate version.
+   - This will cut a new release and create a PR using the latest commits from the `master` branch.
+
+2. **Test the Release**
+   - Test the release PR locally, and check all the boxes. (Never merge this PR manually)
+
+3. **Publish to PyPI**
+   - Go back to the `doof-edx-api-client` Slack channel.
+   - Publish the new release to PyPI using `@doof publish <new-version>` (new-version is the version that you selected upon cutting a new release).
+
+---

--- a/docs/handbook/openedx/edx-platform-development.md
+++ b/docs/handbook/openedx/edx-platform-development.md
@@ -1,0 +1,31 @@
+# Platform Development
+
+### Purpose
+
+At MIT ODL, we often work on edX platform features and bugfixes. There are [multiple named releases of Open edX](https://openedx.atlassian.net/wiki/spaces/DOC/pages/11108700/Open+edX+Releases) and a couple different methods of running the platform on your own machine. This guide aims to be the source of truth for ODL developers in terms of choosing the correct repo/branch for development, running devstack, and troubleshooting an installation.
+
+### Current State of Things
+
+*(updated 04/02/2018)*
+
+This is the state of `edx-platform` development at MIT ODL. If this doesn't make sense, read below.
+
+- MIT ODL main development branch: **`mitx/master`**
+- Accepted method for running devstack on that branch: **Docker**
+- Unless an issue explicitly says otherwise, you should always do `edx-platform` work in the MIT ODL fork, in a branch off of the main development branch specified above, and any PRs should be opened against that branch.
+
+### Running devstack
+
+There are 2 different methods for running devstack on your own machine: Vagrant ([guide](https://openedx.atlassian.net/wiki/spaces/OpenOPS/pages/60227787/Running+Vagrant-based+Devstack)) and Docker ([guide](https://github.com/edx/devstack)). The edX team is focusing all future development on the Docker-based method, starting after the Ginkgo release. MIT ODL developers should run devstack using these guidelines:
+
+1. If you are working on a branch based on the `Ginkgo` release or any release before that, use **Vagrant**. A pre-built vagrant box based on the `mitx/ginkgo` fork can be downloaded [here](https://s3.amazonaws.com/public.mitx.mit.edu/vagrant/mitx-ginkgo/mitx_devstack_ginkgo.tar.gz).
+2. If you are working on a branch based on any release that came after `Ginkgo` (`Hawthorn`, etc.), use **Docker**
+
+### `edx-platform` Repository/Branch
+
+MIT ODL maintains a fork of the `edx-platform` repo.
+
+- MIT ODL fork: https://github.com/mitodl/edx-platform
+- Upstream edX repo: https://github.com/edx/edx-platform
+
+The MIT ODL fork is used for most/all MIT courses that run on the edX platform. Almost all of our edX development work centers around feature additions and bug fixes for MIT courses, so we do most of our work in that fork. We maintain our own IT infrastructure for MIT courses (separate from edX). The 'main development branch' specified above is the branch that releases are created from. We do to put up some PRs against the upstream edX-maintained repo, mostly to make it easier to keep our fork up to date with that repo.

--- a/docs/handbook/openedx/enable-ccx.md
+++ b/docs/handbook/openedx/enable-ccx.md
@@ -1,0 +1,44 @@
+# Enabling CCX
+
+Starting with a fresh install of devstack,
+
+1. Create a private.py for cms (`edx-platform/cms/envs/private.py`) with the following lines:
+
+ ```
+from .devstack import * # pylint: disable=wildcard-import, unused-wildcard-import
+
+FEATURES['CUSTOM_COURSES_EDX'] = True
+ ```
+
+2. Create a private.py for lms (`edx-platform/lms/envs/private.py`) with the following lines:
+
+   ```
+from .devstack import * # pylint: disable=wildcard-import, unused-wildcard-import
+
+FEATURES['CUSTOM_COURSES_EDX'] = True
+
+##### Custom Courses for EdX #####
+if FEATURES.get('CUSTOM_COURSES_EDX'):
+        INSTALLED_APPS += ('ccx',)
+        FIELD_OVERRIDE_PROVIDERS += (
+            'ccx.overrides.CustomCoursesForEdxOverrideProvider',
+        )
+   ```
+
+3. As the edxapp user in vagrant, run `paver update_db`
+
+   The output put should include something like the following:
+
+   ```
+Running migrations for ccx:
+ - Migrating forwards to 0002_convert_memberships.
+ > ccx:0001_initial
+ > ccx:0002_convert_memberships
+ - Migration 'ccx:0002_convert_memberships' is marked for no-dry-run.
+ - Loading initial data for ccx.
+   ```
+
+3. Start the servers with `paver run_all_servers`
+
+3. Continue with the user instructions at
+http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/latest/building_course/custom_courses.html

--- a/docs/handbook/openedx/index.md
+++ b/docs/handbook/openedx/index.md
@@ -1,0 +1,9 @@
+# OpenedX
+
+Legacy guides for working with the Open edX platform at OL.
+
+- [Configuring Themes in edX](configuring_theme_in_edX.md)
+- [edx-api-client Release Process](edx-api-client-release-process.md)
+- [Platform Development](edx-platform-development.md)
+- [Enabling CCX](enable-ccx.md)
+- [Integrating MIT Applications with Open edX using Tutor](MITx-edx-integration-tutor.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,33 @@
 ![MIT Logo 3 Line Black](img/mit_lockup_std-three-line_rgb_black.png)
 
-# Handy Links
+# MIT Open Learning Engineering
 
-## For Engineering
+Documentation for how MIT Open Learning's Engineering and Platform Engineering teams build, ship, and operate software.
+
+<div class="grid cards" markdown>
+
+- :material-book-open-page-variant:{ .lg .middle } __Engineering Handbook__
+
+    ---
+
+    Coding conventions, delivery process, and how-to guides for OL engineers.
+
+    [:octicons-arrow-right-24: Read the Handbook](handbook/index.md)
+
+- :material-server-network:{ .lg .middle } __Platform Engineering__
+
+    ---
+
+    Runbooks, infrastructure, CI/CD, and system architecture for the platforms OL runs on.
+
+    [:octicons-arrow-right-24: Explore Platform Engineering](getting_started_and_how_tos/emergency-break-glass.md)
+
+</div>
+
+## Handy Links
+
+### For Engineering
+
 - [Oncall Emergency Break Glass](getting_started_and_how_tos/emergency-break-glass.md)
 - [Celery Monitoring Production](https://celery-monitoring.odl.mit.edu/)
 - [Concourse Pipelines Production](https://cicd.odl.mit.edu/)
@@ -11,6 +36,7 @@
 - [MIT Online Learning Intranet](https://openlearning-intranet.mit.edu/)
 - [MIT Atlas Status](https://atlas-status.mit.edu/)
 
-## For Platform Engineering
+### For Platform Engineering
+
 - [Oncall Runbook](runbooks_post_mortems/oncall_runbook.md)
 - [Grafana Production](https://mitolproduction.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22grafanacloud-logs%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22%7Benvironment%3D%5C%22mitxonline-production%5C%22,%20application%3D%5C%22edxapp%5C%22%7D%20%7C%20json%20%7C%20log_process%3D%5C%22edxapp%5C%22%20%7C~%20%5C%22motosharky%5C%22%22,%22queryType%22:%22range%22%7D%5D,%22range%22:%7B%22from%22:%22now-24h%22,%22to%22:%22now%22%7D%7D)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,9 +4,18 @@ theme:
   user_color_mode_toggle: true
   features:
     - content.code.copy
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.indexes
+    - navigation.top
 draft_docs: |
   drafts/
 markdown_extensions:
+  - attr_list
+  - md_in_html
+  - pymdownx.emoji:
+      emoji_index: !!python/name:zensical.extensions.emoji.twemoji
+      emoji_generator: !!python/name:zensical.extensions.emoji.to_svg
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span
@@ -32,147 +41,175 @@ extra_javascript:
   - javascripts/c4-zoom.js?v=c53b4ad7
 nav:
   - Home: index.md
-  - Getting Started & How-Tos:
-      - Emergency Oncall Break Glass Procedure: getting_started_and_how_tos/emergency-break-glass.md
-      - Developer EKS Access: getting_started_and_how_tos/developer_eks_access.md
-      - Experimental EKS Access Setup: getting_started_and_how_tos/experimental_eks_access_setup.md
-      - Vault Access for Developers: getting_started_and_how_tos/vault_access_for_developers.md
-      - Updating This Site: getting_started_and_how_tos/update_this_site.md
-      - Applications & Services: getting_started_and_how_tos/pe-product-infra-map.md
-      - Impersonating Users in Keycloak: getting_started_and_how_tos/impersonate_users_keycloak.md
-  - Platform Services:
-      - Secrets Management (Vault):
-          - Restoring Vault Backups: platform_services/secrets_management/restore_vault_backups.md
-          - Faking It with Consul and Vault: platform_services/secrets_management/faking_it_with_consul_and_vault.md
-      - Service Discovery (Consul):
-          - Consul Incantations: platform_services/service_discovery/consul_incantations.md
-          - Fargate Service Discovery: platform_services/service_discovery/fargate_service_discovery.md
-      - Container Orchestration (Kubernetes):
-          - Deploying Apps with Kubernetes: platform_services/container_orchestration/deploying_apps_with_kubernetes.md
-          - Kubernetes Cookbook: platform_services/container_orchestration/kubernetes_cookbook.md
-      - CI/CD (Concourse):
-          - Getting Started with Concourse: platform_services/ci_cd/getting_started_with_concourse.md
-          - Deploying Concourse: platform_services/ci_cd/deploying_concourse.md
-          - Concourse GitHub Issues User Guide: platform_services/ci_cd/concourse_github_issues_user_guide.md
-      - Cloud Infrastructure (AWS & Pulumi):
-          - Pulumi AWS Classic 5 to 6 Upgrade: platform_services/cloud_infrastructure/pulumi_aws_classic_5_to_6_upgrade.md
-          - Importing Existing Resources with Pulumi: platform_services/cloud_infrastructure/import_existing_resources_with_pulumi.md
-          - Testing and Deploying Pulumi Packer Projects: platform_services/cloud_infrastructure/test_and_deploy_pulumi_packer_projects.md
-          - Tagging AMIs with Software Metadata: platform_services/cloud_infrastructure/tagging_amis_with_installed_software_metadata.md
-          - Moira Certificates: platform_services/cloud_infrastructure/moira_certificates.md
-          - Recaptcha: platform_services/cloud_infrastructure/recaptcha.md
-          - Publishing to NPM: platform_services/cloud_infrastructure/publishing_to_npm.md
-  - System Architecture:
-      - SOA System Landscape: system_architecture/landscape.md
-      - MITx Online Open edX:
-          - Architecture & Data Flows: system_architecture/mitxonline-openedx/index.md
-          - System Context: system_architecture/mitxonline-openedx/system-context.md
-          - Containers: system_architecture/mitxonline-openedx/container.md
-          - Data Flows: system_architecture/mitxonline-openedx/data-flows.md
-          - Dependencies & Cycles: system_architecture/mitxonline-openedx/dependencies-and-cycles.md
-      - xPRO Open edX:
-          - Architecture & Data Flows: system_architecture/xpro-openedx/index.md
-          - System Context: system_architecture/xpro-openedx/system-context.md
-          - Containers: system_architecture/xpro-openedx/container.md
-          - Data Flows: system_architecture/xpro-openedx/data-flows.md
-          - Dependencies & Cycles: system_architecture/xpro-openedx/dependencies-and-cycles.md
-      - MIT Learn:
-          - Architecture & Data Flows: system_architecture/mit-learn/index.md
-          - System Context: system_architecture/mit-learn/system-context.md
-          - Containers: system_architecture/mit-learn/container.md
-          - Components: system_architecture/mit-learn/component.md
-          - Data Flows: system_architecture/mit-learn/data-flows.md
-          - Dependencies & Cycles: system_architecture/mit-learn/dependencies-and-cycles.md
-          - Infrastructure References: system_architecture/mit-learn/infrastructure-references.md
-      - learn-ai:
-          - Architecture & Data Flows: system_architecture/learn-ai/index.md
-          - System Context: system_architecture/learn-ai/system-context.md
-          - Containers: system_architecture/learn-ai/container.md
-          - Data Flows: system_architecture/learn-ai/data-flows.md
-          - Dependencies & Cycles: system_architecture/learn-ai/dependencies-and-cycles.md
-      - MITx Online:
-          - Architecture & Data Flows: system_architecture/mitxonline/index.md
-          - System Context: system_architecture/mitxonline/system-context.md
-          - Containers: system_architecture/mitxonline/container.md
-          - Data Flows: system_architecture/mitxonline/data-flows.md
-          - Dependencies & Cycles: system_architecture/mitxonline/dependencies-and-cycles.md
-      - MITx Pro:
-          - Architecture & Data Flows: system_architecture/mitxpro/index.md
-          - System Context: system_architecture/mitxpro/system-context.md
-          - Containers: system_architecture/mitxpro/container.md
-          - Data Flows: system_architecture/mitxpro/data-flows.md
-          - Dependencies & Cycles: system_architecture/mitxpro/dependencies-and-cycles.md
-      - MicroMasters:
-          - Architecture & Data Flows: system_architecture/micromasters/index.md
-          - System Context: system_architecture/micromasters/system-context.md
-          - Containers: system_architecture/micromasters/container.md
-          - Data Flows: system_architecture/micromasters/data-flows.md
-          - Dependencies & Cycles: system_architecture/micromasters/dependencies-and-cycles.md
-      - OCW Studio:
-          - Architecture & Data Flows: system_architecture/ocw-studio/index.md
-          - System Context: system_architecture/ocw-studio/system-context.md
-          - Containers: system_architecture/ocw-studio/container.md
-          - Data Flows: system_architecture/ocw-studio/data-flows.md
-          - Dependencies & Cycles: system_architecture/ocw-studio/dependencies-and-cycles.md
-      - ODL Video Service:
-          - Architecture & Data Flows: system_architecture/odl-video-service/index.md
-          - System Context: system_architecture/odl-video-service/system-context.md
-          - Containers: system_architecture/odl-video-service/container.md
-          - Data Flows: system_architecture/odl-video-service/data-flows.md
-          - Dependencies & Cycles: system_architecture/odl-video-service/dependencies-and-cycles.md
-      - OL Data Platform:
-          - Architecture & Data Flows: system_architecture/ol-data-platform/index.md
-          - System Context: system_architecture/ol-data-platform/system-context.md
-          - Containers: system_architecture/ol-data-platform/container.md
-          - Data Flows: system_architecture/ol-data-platform/data-flows.md
-          - Dependencies & Cycles: system_architecture/ol-data-platform/dependencies-and-cycles.md
-  - Application Specific Guides:
-      - Open edX:
-          - MITx Online Bulk Rescore: application_specific_guides/openedx/mitxonline_bulk_rescore.md
-          - Proving Build Was Deployed: application_specific_guides/openedx/prove_build_was_deployed.md
-          - Accessing Django Manage: application_specific_guides/openedx/access_django_manage.md
-          - Enabling Rapid Response edXApp: application_specific_guides/openedx/enable_rapid_response_edxapp.md
-          - MySQL Access: application_specific_guides/openedx/mysql_access.md
-          - Retirement Pipeline: application_specific_guides/openedx/retirement_pipeline.md
-          - Release Upgrades: application_specific_guides/openedx/release_upgrades.md
-          - Retiring a User: application_specific_guides/openedx/retire_an_openedx_user.md
-          - ProctorTrack:
-              - Integration Overview: application_specific_guides/openedx/proctoring/proctortrack_integration_overview.md
-              - JS Architecture: application_specific_guides/openedx/proctoring/proctoring_js_architecture.md
-              - Build Fix: application_specific_guides/openedx/proctoring/earthfile_fix.md
-              - Workers JSON Build Requirements: application_specific_guides/openedx/proctoring/workers_json_requirements.md
-      - Heroku (Legacy):
-          - Config Vars: application_specific_guides/heroku_legacy/config_vars.md
-          - Dynosaur Management: application_specific_guides/heroku_legacy/dynosaur_management.md
-          - Log Drains: application_specific_guides/heroku_legacy/log_drains.md
-          - Transitioning Postgres DB to RDS: application_specific_guides/heroku_legacy/transition_postgres_db_to_rds.md
-      - OCW Studio:
-          - Updating The OCW Studio Pipeline: application_specific_guides/ocw-studio/Update_OCW_Studio_Pipeline.md
-      - OCW Site:
-          - Accessing S3 Bucket Audit Logs: application_specific_guides/ocw_site/accessing_s3_audit_logs.md
-      - Doof (Odlbot):
-          - Resetting Doof Github Token: application_specific_guides/odlbot/Resetting_Doof_Github_Token.md
-          - Resetting Doof NPMJS Token: application_specific_guides/odlbot/Resetting_Doof_NPM_Token.md
-      - Renovate:
-          - Updating Renovate Configuration: application_specific_guides/renovate/updating_renovate_config.md
-      - JupyterHub:
-          - JupyterHub Admin Guide: application_specific_guides/jupyterhub/jupyterhub_admin_guide.md
-      - Keycloak:
-          - Inviting New Users to Keycloak Realms: application_specific_guides/keycloak/inviting_users_to_realms.md
-  - Monitoring And Observability:
-      - Overview: monitoring_observability/overview.md
-      - Inventory: monitoring_observability/inventory.md
-      - Key Labels: monitoring_observability/key_labels.md
-      - Bumping Sentry Credit: monitoring_observability/bump_sentry_credit.md
-      - Managing Rootly: monitoring_observability/rootly_management.md
-  - Runbooks & Post-Mortems:
-      - On-Call Runbook: runbooks_post_mortems/oncall_runbook.md
-      - OL Production Outage Runbook: runbooks_post_mortems/ol_production_outage_runbook.md
-      - 20231030 xPro Outage Post-Mortem: runbooks_post_mortems/20231030_xpro_outage.md
-      - 20260423 MIT Learn Outage Post-Mortem: runbooks_post_mortems/20260324_mitlearn_outage.md
-      - 20260603 MIT XPro Certificate Outage Post Mortem: runbooks_post_mortems/20260603_xpro_outage.md
-      - Clear User Grades In Open edX: runbooks_post_mortems/openedx_clear_user_grades.md
-  - Cookbooks & Patterns:
-      - DevOps Patterns Cookbook: cookbooks_patterns/devops_patterns_cookbook.md
-  - Partner Documentation:
-      - Integrating With MIT Learn SSO: sso_onboarding/sso_config.md
+  - Engineering Handbook:
+      - Overview: handbook/index.md
+      - How We Deliver:
+          - Overview: handbook/delivering/index.md
+          - Code Review: handbook/delivering/code-review.md
+          - Development Process: handbook/delivering/development-process.md
+          - Environments: handbook/delivering/environments.md
+          - How We Work: handbook/delivering/how-we-work.md
+          - Production Ready: handbook/delivering/production-ready.md
+          - Release Process:
+              - Overview: handbook/delivering/release-process/index.md
+              - Webapp Release Process: handbook/delivering/release-process/webapp-release-process.md
+      - How-To Guides:
+          - Overview: handbook/how-to/index.md
+          - Caching: handbook/how-to/caching.md
+          - Common Web App Guide: handbook/how-to/common-web-app-guide.md
+          - New Projects: handbook/how-to/new-projects.md
+          - Touchstone Integration: handbook/how-to/touchstone.md
+      - Open edX (Legacy Handbook):
+          - Overview: handbook/openedx/index.md
+          - Configuring Themes in edX: handbook/openedx/configuring_theme_in_edX.md
+          - edx-api-client Release Process: handbook/openedx/edx-api-client-release-process.md
+          - Platform Development: handbook/openedx/edx-platform-development.md
+          - Enabling CCX: handbook/openedx/enable-ccx.md
+          - Integrating MIT Applications with Open edX using Tutor: handbook/openedx/MITx-edx-integration-tutor.md
+      - Deprecated Docs:
+          - Integrating MIT Applications with Open edX using Devstack: handbook/deprecated-docs/MITx-edx-integration-devstack.md
+  - Platform Engineering:
+      - Getting Started & How-Tos:
+          - Emergency Oncall Break Glass Procedure: getting_started_and_how_tos/emergency-break-glass.md
+          - Developer EKS Access: getting_started_and_how_tos/developer_eks_access.md
+          - Experimental EKS Access Setup: getting_started_and_how_tos/experimental_eks_access_setup.md
+          - Vault Access for Developers: getting_started_and_how_tos/vault_access_for_developers.md
+          - Updating This Site: getting_started_and_how_tos/update_this_site.md
+          - Applications & Services: getting_started_and_how_tos/pe-product-infra-map.md
+          - Impersonating Users in Keycloak: getting_started_and_how_tos/impersonate_users_keycloak.md
+      - Platform Services:
+          - Secrets Management (Vault):
+              - Restoring Vault Backups: platform_services/secrets_management/restore_vault_backups.md
+              - Faking It with Consul and Vault: platform_services/secrets_management/faking_it_with_consul_and_vault.md
+          - Service Discovery (Consul):
+              - Consul Incantations: platform_services/service_discovery/consul_incantations.md
+              - Fargate Service Discovery: platform_services/service_discovery/fargate_service_discovery.md
+          - Container Orchestration (Kubernetes):
+              - Deploying Apps with Kubernetes: platform_services/container_orchestration/deploying_apps_with_kubernetes.md
+              - Kubernetes Cookbook: platform_services/container_orchestration/kubernetes_cookbook.md
+          - CI/CD (Concourse):
+              - Getting Started with Concourse: platform_services/ci_cd/getting_started_with_concourse.md
+              - Deploying Concourse: platform_services/ci_cd/deploying_concourse.md
+              - Concourse GitHub Issues User Guide: platform_services/ci_cd/concourse_github_issues_user_guide.md
+          - Cloud Infrastructure (AWS & Pulumi):
+              - Pulumi AWS Classic 5 to 6 Upgrade: platform_services/cloud_infrastructure/pulumi_aws_classic_5_to_6_upgrade.md
+              - Importing Existing Resources with Pulumi: platform_services/cloud_infrastructure/import_existing_resources_with_pulumi.md
+              - Testing and Deploying Pulumi Packer Projects: platform_services/cloud_infrastructure/test_and_deploy_pulumi_packer_projects.md
+              - Tagging AMIs with Software Metadata: platform_services/cloud_infrastructure/tagging_amis_with_installed_software_metadata.md
+              - Moira Certificates: platform_services/cloud_infrastructure/moira_certificates.md
+              - Recaptcha: platform_services/cloud_infrastructure/recaptcha.md
+              - Publishing to NPM: platform_services/cloud_infrastructure/publishing_to_npm.md
+      - System Architecture:
+          - SOA System Landscape: system_architecture/landscape.md
+          - MITx Online Open edX:
+              - Architecture & Data Flows: system_architecture/mitxonline-openedx/index.md
+              - System Context: system_architecture/mitxonline-openedx/system-context.md
+              - Containers: system_architecture/mitxonline-openedx/container.md
+              - Data Flows: system_architecture/mitxonline-openedx/data-flows.md
+              - Dependencies & Cycles: system_architecture/mitxonline-openedx/dependencies-and-cycles.md
+          - xPRO Open edX:
+              - Architecture & Data Flows: system_architecture/xpro-openedx/index.md
+              - System Context: system_architecture/xpro-openedx/system-context.md
+              - Containers: system_architecture/xpro-openedx/container.md
+              - Data Flows: system_architecture/xpro-openedx/data-flows.md
+              - Dependencies & Cycles: system_architecture/xpro-openedx/dependencies-and-cycles.md
+          - MIT Learn:
+              - Architecture & Data Flows: system_architecture/mit-learn/index.md
+              - System Context: system_architecture/mit-learn/system-context.md
+              - Containers: system_architecture/mit-learn/container.md
+              - Components: system_architecture/mit-learn/component.md
+              - Data Flows: system_architecture/mit-learn/data-flows.md
+              - Dependencies & Cycles: system_architecture/mit-learn/dependencies-and-cycles.md
+              - Infrastructure References: system_architecture/mit-learn/infrastructure-references.md
+          - learn-ai:
+              - Architecture & Data Flows: system_architecture/learn-ai/index.md
+              - System Context: system_architecture/learn-ai/system-context.md
+              - Containers: system_architecture/learn-ai/container.md
+              - Data Flows: system_architecture/learn-ai/data-flows.md
+              - Dependencies & Cycles: system_architecture/learn-ai/dependencies-and-cycles.md
+          - MITx Online:
+              - Architecture & Data Flows: system_architecture/mitxonline/index.md
+              - System Context: system_architecture/mitxonline/system-context.md
+              - Containers: system_architecture/mitxonline/container.md
+              - Data Flows: system_architecture/mitxonline/data-flows.md
+              - Dependencies & Cycles: system_architecture/mitxonline/dependencies-and-cycles.md
+          - MITx Pro:
+              - Architecture & Data Flows: system_architecture/mitxpro/index.md
+              - System Context: system_architecture/mitxpro/system-context.md
+              - Containers: system_architecture/mitxpro/container.md
+              - Data Flows: system_architecture/mitxpro/data-flows.md
+              - Dependencies & Cycles: system_architecture/mitxpro/dependencies-and-cycles.md
+          - MicroMasters:
+              - Architecture & Data Flows: system_architecture/micromasters/index.md
+              - System Context: system_architecture/micromasters/system-context.md
+              - Containers: system_architecture/micromasters/container.md
+              - Data Flows: system_architecture/micromasters/data-flows.md
+              - Dependencies & Cycles: system_architecture/micromasters/dependencies-and-cycles.md
+          - OCW Studio:
+              - Architecture & Data Flows: system_architecture/ocw-studio/index.md
+              - System Context: system_architecture/ocw-studio/system-context.md
+              - Containers: system_architecture/ocw-studio/container.md
+              - Data Flows: system_architecture/ocw-studio/data-flows.md
+              - Dependencies & Cycles: system_architecture/ocw-studio/dependencies-and-cycles.md
+          - ODL Video Service:
+              - Architecture & Data Flows: system_architecture/odl-video-service/index.md
+              - System Context: system_architecture/odl-video-service/system-context.md
+              - Containers: system_architecture/odl-video-service/container.md
+              - Data Flows: system_architecture/odl-video-service/data-flows.md
+              - Dependencies & Cycles: system_architecture/odl-video-service/dependencies-and-cycles.md
+          - OL Data Platform:
+              - Architecture & Data Flows: system_architecture/ol-data-platform/index.md
+              - System Context: system_architecture/ol-data-platform/system-context.md
+              - Containers: system_architecture/ol-data-platform/container.md
+              - Data Flows: system_architecture/ol-data-platform/data-flows.md
+              - Dependencies & Cycles: system_architecture/ol-data-platform/dependencies-and-cycles.md
+      - Application Specific Guides:
+          - Open edX:
+              - MITx Online Bulk Rescore: application_specific_guides/openedx/mitxonline_bulk_rescore.md
+              - Proving Build Was Deployed: application_specific_guides/openedx/prove_build_was_deployed.md
+              - Accessing Django Manage: application_specific_guides/openedx/access_django_manage.md
+              - Enabling Rapid Response edXApp: application_specific_guides/openedx/enable_rapid_response_edxapp.md
+              - MySQL Access: application_specific_guides/openedx/mysql_access.md
+              - Retirement Pipeline: application_specific_guides/openedx/retirement_pipeline.md
+              - Release Upgrades: application_specific_guides/openedx/release_upgrades.md
+              - Retiring a User: application_specific_guides/openedx/retire_an_openedx_user.md
+              - ProctorTrack:
+                  - Integration Overview: application_specific_guides/openedx/proctoring/proctortrack_integration_overview.md
+                  - JS Architecture: application_specific_guides/openedx/proctoring/proctoring_js_architecture.md
+                  - Build Fix: application_specific_guides/openedx/proctoring/earthfile_fix.md
+                  - Workers JSON Build Requirements: application_specific_guides/openedx/proctoring/workers_json_requirements.md
+          - Heroku (Legacy):
+              - Config Vars: application_specific_guides/heroku_legacy/config_vars.md
+              - Dynosaur Management: application_specific_guides/heroku_legacy/dynosaur_management.md
+              - Log Drains: application_specific_guides/heroku_legacy/log_drains.md
+              - Transitioning Postgres DB to RDS: application_specific_guides/heroku_legacy/transition_postgres_db_to_rds.md
+          - OCW Studio:
+              - Updating The OCW Studio Pipeline: application_specific_guides/ocw-studio/Update_OCW_Studio_Pipeline.md
+          - OCW Site:
+              - Accessing S3 Bucket Audit Logs: application_specific_guides/ocw_site/accessing_s3_audit_logs.md
+          - Doof (Odlbot):
+              - Resetting Doof Github Token: application_specific_guides/odlbot/Resetting_Doof_Github_Token.md
+              - Resetting Doof NPMJS Token: application_specific_guides/odlbot/Resetting_Doof_NPM_Token.md
+          - Renovate:
+              - Updating Renovate Configuration: application_specific_guides/renovate/updating_renovate_config.md
+          - JupyterHub:
+              - JupyterHub Admin Guide: application_specific_guides/jupyterhub/jupyterhub_admin_guide.md
+          - Keycloak:
+              - Inviting New Users to Keycloak Realms: application_specific_guides/keycloak/inviting_users_to_realms.md
+      - Monitoring And Observability:
+          - Overview: monitoring_observability/overview.md
+          - Inventory: monitoring_observability/inventory.md
+          - Key Labels: monitoring_observability/key_labels.md
+          - Bumping Sentry Credit: monitoring_observability/bump_sentry_credit.md
+          - Managing Rootly: monitoring_observability/rootly_management.md
+      - Runbooks & Post-Mortems:
+          - On-Call Runbook: runbooks_post_mortems/oncall_runbook.md
+          - OL Production Outage Runbook: runbooks_post_mortems/ol_production_outage_runbook.md
+          - 20231030 xPro Outage Post-Mortem: runbooks_post_mortems/20231030_xpro_outage.md
+          - 20260423 MIT Learn Outage Post-Mortem: runbooks_post_mortems/20260324_mitlearn_outage.md
+          - 20260603 MIT XPro Certificate Outage Post Mortem: runbooks_post_mortems/20260603_xpro_outage.md
+          - Clear User Grades In Open edX: runbooks_post_mortems/openedx_clear_user_grades.md
+      - Cookbooks & Patterns:
+          - DevOps Patterns Cookbook: cookbooks_patterns/devops_patterns_cookbook.md
+      - Partner Documentation:
+          - Integrating With MIT Learn SSO: sso_onboarding/sso_config.md


### PR DESCRIPTION
## What

Integrates the content of [mitodl/handbook](https://github.com/mitodl/handbook) (currently Jekyll, published at https://mitodl.github.io/handbook/) into this site, and adds clear top-level navigation between it and the existing Platform Engineering content.

## Changes

- **`docs/handbook/`** (new, 21 files): full Engineering Handbook content copied over, Jekyll/just-the-docs front matter (`layout`, `parent`, `grand_parent`, `has_children`, `nav_order`) stripped since mkdocs/zensical nav is defined centrally in `mkdocs.yml`. 5 index pages that had no real body (or Jekyll-only front matter) got short hand-written intros; the old root `index.md`'s Jekyll/Ruby local-preview instructions were dropped as no longer applicable.
- **`mkdocs.yml`**: nav restructured into three top-level tabs via `navigation.tabs`:
  - `Home` — landing page
  - `Engineering Handbook` — new, all `handbook/**` content
  - `Platform Engineering` — wraps the *entire* previously-existing nav tree, unchanged
  - Also enabled `navigation.tabs.sticky`, `navigation.indexes`, `navigation.top`, and added `attr_list`, `md_in_html`, `pymdownx.emoji` markdown extensions (needed for the landing page's grid cards + icons).
- **`docs/index.md`**: redesigned as a landing hub — logo, intro, a 2-card grid (material/octicons icons) linking to each section, with the existing "Handy Links" quick-link lists preserved below.

## Verification

`uv run zensical build` is clean (no issues), all 135 pages build, 3 nav tabs render, grid cards render with working icons/links, spot-checked handbook pages render with correct titles.

## Out of scope for this PR

The old `mitodl/handbook` repo and its GitHub Pages site are untouched — what (if anything) to do with them is a separate follow-up decision.

Ref: mitodl/ol-infrastructure#4884